### PR TITLE
add newline before code block with to-be-ported documentation in rst format

### DIFF
--- a/docs/archived-easyconfigs.md
+++ b/docs/archived-easyconfigs.md
@@ -12,7 +12,8 @@
     - target: [`docs/archived-easyconfigs.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/archived-easyconfigs.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _archived_easyconfigs:
 
 Archived easyconfigs

--- a/docs/backup-modules.md
+++ b/docs/backup-modules.md
@@ -12,7 +12,8 @@
     - target: [`docs/backup-modules.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/backup-modules.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _backup_modules:
 
 Backing up of existing modules (``--backup-modules``)

--- a/docs/changelog-docs.md
+++ b/docs/changelog-docs.md
@@ -15,7 +15,8 @@
     - target: [`docs/changelog-docs.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/changelog-docs.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _changelog:
 
 Changelog for EasyBuild documentation

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -12,7 +12,8 @@
     - target: [`docs/code-style.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/code-style.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 
 .. _code_style:
 

--- a/docs/common-toolchains.md
+++ b/docs/common-toolchains.md
@@ -12,7 +12,8 @@
     - target: [`docs/common-toolchains.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/common-toolchains.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _common_toolchains:
 
 Common toolchains

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,8 @@
     - target: [`docs/configuration.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/configuration.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _configuring_easybuild:
 
 Configuring EasyBuild

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -12,7 +12,8 @@
     - target: [`docs/containers.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/containers.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _containers:
 
 Generating container recipes & images

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,7 +12,8 @@
     - target: [`docs/contributing.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/contributing.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _contributing:
 
 Contributing

--- a/docs/controlling-compiler-optimization-flags.md
+++ b/docs/controlling-compiler-optimization-flags.md
@@ -12,7 +12,8 @@
     - target: [`docs/controlling-compiler-optimization-flags.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/controlling-compiler-optimization-flags.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _controlling_compiler_optimization_flags:
 
 Controlling compiler optimization flags

--- a/docs/cray-support.md
+++ b/docs/cray-support.md
@@ -12,7 +12,8 @@
     - target: [`docs/cray-support.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/cray-support.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _cray_support:
 
 EasyBuild on Cray

--- a/docs/deprecated-easyconfigs.md
+++ b/docs/deprecated-easyconfigs.md
@@ -12,7 +12,8 @@
     - target: [`docs/deprecated-easyconfigs.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/deprecated-easyconfigs.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _deprecated_easyconfigs:
 
 Deprecated easyconfigs

--- a/docs/deprecated-functionality.md
+++ b/docs/deprecated-functionality.md
@@ -13,7 +13,8 @@
     - target: [`docs/deprecated-functionality.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/deprecated-functionality.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _deprecated:
 
 Deprecated functionality

--- a/docs/detecting-loaded-modules.md
+++ b/docs/detecting-loaded-modules.md
@@ -12,7 +12,8 @@
     - target: [`docs/detecting-loaded-modules.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/detecting-loaded-modules.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _detecting_loaded_modules:
 
 Detection of loaded modules

--- a/docs/easyconfig-files-local-variables.md
+++ b/docs/easyconfig-files-local-variables.md
@@ -12,7 +12,8 @@
     - target: [`docs/easyconfig-files-local-variables.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/easyconfig-files-local-variables.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _easyconfig_files_local_variables:
 
 Local variables in easyconfig files

--- a/docs/easystack-files.md
+++ b/docs/easystack-files.md
@@ -12,7 +12,8 @@
     - target: [`docs/easystack-files.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/easystack-files.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _easystack:
 
 Easystack files

--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -12,7 +12,8 @@
     - target: [`docs/experimental-features.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/experimental-features.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _experimental_features:
 
 Experimental features

--- a/docs/extended-dry-run.md
+++ b/docs/extended-dry-run.md
@@ -27,7 +27,8 @@
     - target: [`examples` section of `docs/extended-dry-run.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/extended-dry-run.md#examples)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _extended_dry_run_examples:
 
 Extended dry run: examples
@@ -552,7 +553,8 @@ WRF v3.6.1 with intel/2015a
 
 
 ```
-```
+
+```rst
 .. _extended_dry_run:
 
 Extended dry run

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -12,7 +12,8 @@
     - target: [`docs/hooks.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/hooks.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _hooks:
 
 Hooks

--- a/docs/implementing-easyblocks.md
+++ b/docs/implementing-easyblocks.md
@@ -12,7 +12,8 @@
     - target: [`docs/implementing-easyblocks.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/implementing-easyblocks.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _implementing_easyblocks:
 
 Implementing easyblocks

--- a/docs/including-additional-python-modules.md
+++ b/docs/including-additional-python-modules.md
@@ -12,7 +12,8 @@
     - target: [`docs/including-additional-python-modules.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/including-additional-python-modules.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _including_additional_python_modules:
 
 Including additional Python modules (``--include-*``)

--- a/docs/installation-alternative.md
+++ b/docs/installation-alternative.md
@@ -12,7 +12,8 @@
     - target: [`docs/installation-alternative.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/installation-alternative.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 
 .. toctree::
      :maxdepth: 1

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,8 @@
     - target: [`docs/installation.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/installation.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _installation:
 
 Installing EasyBuild

--- a/docs/installing-environment-modules-without-root-permissions.md
+++ b/docs/installing-environment-modules-without-root-permissions.md
@@ -12,7 +12,8 @@
     - target: [`docs/installing-environment-modules-without-root-permissions.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/installing-environment-modules-without-root-permissions.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 
 .. _installing_env_mod_c:
 

--- a/docs/installing-extensions-in-parallel.md
+++ b/docs/installing-extensions-in-parallel.md
@@ -12,7 +12,8 @@
     - target: [`docs/installing-extensions-in-parallel.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/installing-extensions-in-parallel.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _installing_extensions_in_parallel:
 
 Installing extensions in parallel (experimental!)

--- a/docs/installing-lmod-without-root-permissions.md
+++ b/docs/installing-lmod-without-root-permissions.md
@@ -12,7 +12,8 @@
     - target: [`docs/installing-lmod-without-root-permissions.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/installing-lmod-without-root-permissions.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 
 .. _installing_lmod:
 

--- a/docs/integration-with-github.md
+++ b/docs/integration-with-github.md
@@ -12,7 +12,8 @@
     - target: [`docs/integration-with-github.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/integration-with-github.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _integration_with_github:
 
 Integration with GitHub

--- a/docs/locks.md
+++ b/docs/locks.md
@@ -12,7 +12,8 @@
     - target: [`docs/locks.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/locks.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _locks:
 
 Locks to prevent duplicate installations running at the same time

--- a/docs/log-files.md
+++ b/docs/log-files.md
@@ -12,7 +12,8 @@
     - target: [`docs/log-files.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/log-files.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _understanding_easyBuild_logs:
 
 Understanding EasyBuild logs

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -12,7 +12,8 @@
     - target: [`docs/maintainers.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/maintainers.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _maintainers:
 
 EasyBuild maintainers

--- a/docs/manipulating-dependencies.md
+++ b/docs/manipulating-dependencies.md
@@ -12,7 +12,8 @@
     - target: [`docs/manipulating-dependencies.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/manipulating-dependencies.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _manipulating_dependencies:
 
 Manipulating dependencies

--- a/docs/packaging-support.md
+++ b/docs/packaging-support.md
@@ -12,7 +12,8 @@
     - target: [`docs/packaging-support.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/packaging-support.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _packaging_support:
 
 Packaging support

--- a/docs/partial-installations.md
+++ b/docs/partial-installations.md
@@ -12,7 +12,8 @@
     - target: [`docs/partial-installations.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/partial-installations.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _partial_installations:
 
 Partial installations

--- a/docs/progress-bars.md
+++ b/docs/progress-bars.md
@@ -12,7 +12,8 @@
     - target: [`docs/progress-bars.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/progress-bars.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _progress_bars:
 
 Progress bars

--- a/docs/python-2-3-compatibility.md
+++ b/docs/python-2-3-compatibility.md
@@ -12,7 +12,8 @@
     - target: [`docs/python-2-3-compatibility.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/python-2-3-compatibility.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _py2_py3_compatibility:
 
 Compatibility with Python 2 and Python 3

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,7 +12,8 @@
     - target: [`docs/release-notes.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/release-notes.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _release_notes:
 
 EasyBuild release notes

--- a/docs/removed-functionality.md
+++ b/docs/removed-functionality.md
@@ -12,7 +12,8 @@
     - target: [`docs/removed-functionality.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/removed-functionality.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _removed_functionality:
 
 Removed functionality

--- a/docs/rpath-support.md
+++ b/docs/rpath-support.md
@@ -12,7 +12,8 @@
     - target: [`docs/rpath-support.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/rpath-support.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _rpath_support:
 
 Support for RPATH

--- a/docs/submitting-jobs.md
+++ b/docs/submitting-jobs.md
@@ -12,7 +12,8 @@
     - target: [`docs/submitting-jobs.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/submitting-jobs.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _submitting_jobs:
 
 Submitting jobs using ``--job``

--- a/docs/system-toolchain.md
+++ b/docs/system-toolchain.md
@@ -12,7 +12,8 @@
     - target: [`docs/system-toolchain.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/system-toolchain.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _system_toolchain:
 
 System toolchain

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -12,7 +12,8 @@
     - target: [`docs/terminology.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/terminology.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _concepts_and_terminology:
 
 Concepts and terminology

--- a/docs/tracing-progress.md
+++ b/docs/tracing-progress.md
@@ -12,7 +12,8 @@
     - target: [`docs/tracing-progress.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/tracing-progress.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _trace:
 
 Tracing progress

--- a/docs/typical-workflow-example-with-wrf.md
+++ b/docs/typical-workflow-example-with-wrf.md
@@ -12,7 +12,8 @@
     - target: [`docs/typical-workflow-example-with-wrf.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/typical-workflow-example-with-wrf.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _typical_workflow:
 
 Typical workflow example: building and installing WRF

--- a/docs/unit-tests.md
+++ b/docs/unit-tests.md
@@ -12,7 +12,8 @@
     - target: [`docs/unit-tests.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/unit-tests.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _unit_tests:
 
 Unit tests

--- a/docs/useful-links.md
+++ b/docs/useful-links.md
@@ -12,7 +12,8 @@
     - target: [`docs/useful-links.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/useful-links.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 
 .. _useful_links:
 

--- a/docs/useful-scripts.md
+++ b/docs/useful-scripts.md
@@ -12,7 +12,8 @@
     - target: [`docs/useful-scripts.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/useful-scripts.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _useful_scripts:
 
 Useful scripts

--- a/docs/using-easybuild.md
+++ b/docs/using-easybuild.md
@@ -14,7 +14,8 @@
     - target: [`docs/using-easybuild.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/using-easybuild.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _using_the_easybuild_command_line:
 
 Using the EasyBuild command line

--- a/docs/using-external-modules.md
+++ b/docs/using-external-modules.md
@@ -12,7 +12,8 @@
     - target: [`docs/using-external-modules.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/using-external-modules.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _using_external_modules:
 
 Using external modules

--- a/docs/what-is-easybuild.md
+++ b/docs/what-is-easybuild.md
@@ -12,7 +12,8 @@
     - target: [`docs/what-is-easybuild.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/what-is-easybuild.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _what_is_easybuild:
 
 What is EasyBuild?

--- a/docs/wrapping-dependencies.md
+++ b/docs/wrapping-dependencies.md
@@ -12,7 +12,8 @@
     - target: [`docs/wrapping-dependencies.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/wrapping-dependencies.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _wrapping_dependencies:
 
 Wrapping dependencies

--- a/docs/writing-easyconfig-files.md
+++ b/docs/writing-easyconfig-files.md
@@ -12,7 +12,8 @@
     - target: [`docs/writing-easyconfig-files.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/writing-easyconfig-files.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _writing_easyconfig_files:
 
 Writing easyconfig files: the basics

--- a/docs/writing-yeb-easyconfig-files.md
+++ b/docs/writing-yeb-easyconfig-files.md
@@ -12,7 +12,8 @@
     - target: [`docs/writing-yeb-easyconfig-files.md` in `easybuilders/easybuild-docs` repo](https://github.com/easybuilders/easybuild-docs/tree/main/docs/writing-yeb-easyconfig-files.md)
 
     See <https://github.com/easybuilders/easybuild-docs> for more information.
-```
+
+```rst
 .. _easyconfig_yeb_format:
 
 Writing easyconfig files in YAML syntax (``.yeb`` format) **[IN DEVELOPMENT]**


### PR DESCRIPTION
```shell
sed '0,/```/{s/```/\n```rst/}' -i docs/extended-dry-run.md
```

This means that the linter correctly picks up the code block. For #3