### PR TITLE
enable "Back to top" option in MkDocs configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ theme:
   favicon: favicon.ico
   features:
     - instant
+    - navigation.top
   palette:
     scheme: easybuild
 extra_css:


### PR DESCRIPTION
This adds a 'Back to top' link that appears when you are scrolling up on a page.