### PR TITLE
enable "Integrated table of contents" feature in MkDocs configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ theme:
   favicon: favicon.ico
   features:
     - instant
+    - toc.integrate
   palette:
     scheme: easybuild
 extra_css:


### PR DESCRIPTION
This is an option that we should consider using.

Rather than putting the table of contents for the page on the right, this integrates the table of contents for the page being viewed into the main table of contents.

The main advantage of this is it gives more screen space to the page content.