### PR TITLE
Allow references using attr_list and mkdocs-autorefs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -528,7 +528,7 @@ so you do not need to adjust ``$MODULEPATH`` every time you start a new session.
 
 ```
 
-### Easyconfigs repository (``--repository``, ``--repositorypath``)
+### Easyconfigs repository (``--repository``, ``--repositorypath``) {: #configuration-easyconfigs-repository }
 
 ```rst
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -18,15 +18,14 @@ are fully accessible (and modifiable) from within hook implementations. Hence, t
 provides a lot of flexibility to change the EasyBuild functionality should you require it,
 without having to modify the codebase of EasyBuild itself.
 
-
-## Configuring EasyBuild to use your hook implementations
+## Configuring EasyBuild to use your hook implementations {: #some_slug }
 
 To instruct EasyBuild to use your hook implementations,
 you only need to specify the location of the Python module (`*.py`) that implements them.
 
 This is done via the `--hooks` configuration option
 (or equivalently via the `$EASYBUILD_HOOKS` environment variable, or via `hooks = ...`
-in an EasyBuild configuration file, see also [Configuring EasyBuild](configuration.md#configuring-easybuild)).
+in an EasyBuild configuration file, see also [Configuring EasyBuild][configuring-easybuild]).
 
 For example:
 
@@ -230,7 +229,7 @@ See also [Example hook to inject a custom patch file](#inject-a-custom-patch-fil
 
 EasyBuild archives the easyconfig file that was used for a particular installation:
 A copy is stored both in the `easybuild` subdirectory of the software installation
-directory and in the easyconfigs repository (see [Easyconfigs repository](configuration.md#easyconfigs-repository-repository-repositorypath)).
+directory and in the easyconfigs repository (see [Easyconfigs repository][configuration-easyconfigs-repository]).
 
 If any changes were made to the easyconfig file via hooks, these changes will *not* be
 reflected in these copies.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -18,7 +18,7 @@ are fully accessible (and modifiable) from within hook implementations. Hence, t
 provides a lot of flexibility to change the EasyBuild functionality should you require it,
 without having to modify the codebase of EasyBuild itself.
 
-## Configuring EasyBuild to use your hook implementations {: #some_slug }
+## Configuring EasyBuild to use your hook implementations
 
 To instruct EasyBuild to use your hook implementations,
 you only need to specify the location of the Python module (`*.py`) that implements them.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,8 @@ nav:
   - Getting help: getting-help.md
 
 markdown_extensions:
+  # add attributes to html elements
+  - attr_list
   # notes, warnings, hints, ...
   - admonition
   # code blocks with syntax highlighting, graphs
@@ -53,6 +55,8 @@ extra:
       link: https://docs.easybuild.io
 
 plugins:
+  # autolinks across pages
+  - autorefs
   # show revision date at bottom of each page
   - git-revision-date-localized
   # necessary for search to work

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mkdocs
 mkdocs-material
 mkdocs-redirects
 mkdocs-git-revision-date-localized-plugin
+mkdocs-autorefs


### PR DESCRIPTION
Use:
* [`attr_list`](https://python-markdown.github.io/extensions/attr_list/)
* [`mkdocs-autorefs`](https://github.com/mkdocstrings/autorefs)

Combined these allow us to more easily replace the `:ref:` that are in the current documentation.


We can define a html anchor with:
```mk
{: #anchor }
```

And we can link to it with:
```mk
[link to the anchor][anchor]
```
Note that that uses `[][]` instead of the standard link that uses `[]()`.


For headers an anchor is added to the end of a line:
```mk
## My header {: #linkify }
```

For a block element you add it on a separate line, so:
```mk
This is my paragraph
{: #paragraph_anchor }
```

We can also leave Mkdocs to generate a standard header anchor, such as in
```
### Header
```
and still use `[link to that section][header]` to link to it.