### PR TITLE
fix (temporary) site URL in mkdocs configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: EasyBuild - building software with ease 
-site_url: https://docs.easybuild.io
+site_url: https://easybuilders.github.io/easybuild-docs
 extra:
   analytics:
     provider: google


### PR DESCRIPTION
There's no data coming into Google Analytics yet, despite that MkDocs is configured with the correct measurement ID.

I'm not sure if the `site_url` is the culprit, but it's definitely incorrect currently, since `docs.easybuild.io` still points to the documentation that is served at https://easybuild.readthedocs.io .