### PR TITLE
mkapi test (WIP)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           check_filenames: true
           ignore_words_list: atleast,ninjs,simpy,proovread,namd,precice
+          path: docs
 
       - name: check internal links
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,12 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
 
+      - name: Check out branfosj/easybuild-framework
+        uses: actions/checkout@v3
+        with:
+          repository: branfosj/easybuild-framework
+          ref: doc
+
       - name: set up Python
         uses: actions/setup-python@v4
         with:
@@ -28,6 +34,9 @@ jobs:
         run: |
           pip install -r requirements.txt
           mkdocs --version
+
+      - name: install branfosj/easybuild-framework
+        run: (cd ../easybuild-framework && pip install -e .)
 
       - name: build tutorial
         # can't use --strict due to warnings being produced by mkdocs-redirect plugin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,15 +8,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
-        with:
-          path: docs
-
-      - name: Check out branfosj/easybuild-framework
-        uses: actions/checkout@v3
-        with:
-          repository: branfosj/easybuild-framework
-          ref: doc
-          path: easybuild-framework
 
       - name: set up Python
         uses: actions/setup-python@v4
@@ -28,24 +19,17 @@ jobs:
         with:
           check_filenames: true
           ignore_words_list: atleast,ninjs,simpy,proovread,namd,precice
-          path: docs
 
       - name: check internal links
-        run: |
-          python ./.github/workflows/link_check.py
+        run: python ./.github/workflows/link_check.py
 
       - name: install mkdocs
         run: |
           pip install -r requirements.txt
           mkdocs --version
 
-      - name: install branfosj/easybuild-framework
-        run: (cd easybuild-framework && pip install -e .)
-
       - name: build tutorial
         # can't use --strict due to warnings being produced by mkdocs-redirect plugin
         # because we are re-directing .html pages
         # run: mkdocs build --strict
-        run: |
-          cd docs
-          mkdocs build
+        run: mkdocs build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,15 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+        with:
+          path: docs
 
       - name: Check out branfosj/easybuild-framework
         uses: actions/checkout@v3
         with:
           repository: branfosj/easybuild-framework
           ref: doc
+          path: easybuild-framework
 
       - name: set up Python
         uses: actions/setup-python@v4
@@ -36,10 +39,12 @@ jobs:
           mkdocs --version
 
       - name: install branfosj/easybuild-framework
-        run: (cd ../easybuild-framework && pip install -e .)
+        run: (cd easybuild-framework && pip install -e .)
 
       - name: build tutorial
         # can't use --strict due to warnings being produced by mkdocs-redirect plugin
         # because we are re-directing .html pages
         # run: mkdocs build --strict
-        run: mkdocs build
+        run: |
+          cd docs
+          mkdocs build

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -131,3 +131,67 @@
 [data-md-color-switching] *::after {
   transition-duration: 0ms !important; /* stylelint-disable-line */
 }
+
+/* mkapi */
+.mkapi-section-name-body {
+  color: var(--md-typeset-color);
+  font-weight: inherit;
+  letter-spacing: inherit;
+}
+
+.mkapi-item-type,
+.mkapi-object-kind.module,
+.mkapi-object-kind.package,
+.mkapi-section-name-body.bases {
+  color: var(--eb-green);
+}
+
+.mkapi-items code.mkapi-item-name,
+.mkapi-items code.mkapi-object-parenthesis,
+.mkapi-items code.mkapi-object-signature {
+  background-color: inherit;
+  color: inherit;
+}
+
+a.mkapi-docs-link,
+a.mkapi-src-link,
+.mkapi-item-name a:hover {
+  background-color: inherit;
+}
+
+a.mkapi-src-link:hover,
+a.mkapi-docs-link:hover {
+  border-color: var(--eb-blue);
+  background-color: var(--eb-green);
+  color: var(--md-default-bg-color);
+}
+
+.mkapi-object-body code.mkapi-object-parenthesis,
+.mkapi-object-body code.mkapi-object-signature,
+.mkapi-node .mkapi-object-body.top code.mkapi-object-parenthesis,
+.mkapi-node .mkapi-object-body.top code.mkapi-object-signature {
+  color: var(--md-code-hl-keyword-color);
+}
+
+.mkapi-object-kind.top {
+  color: var(--md-code-hl-operator-color);
+}
+
+code.mkapi-object-name,
+code.mkapi-object-prefix {
+  color: var(--md-code-hl-name-color);
+}
+
+div.mkapi-object.class.code,
+div.mkapi-object.class.top.code,
+div.mkapi-object.function.code,
+div.mkapi-object.function.top.code,
+div.mkapi-object.generator.code,
+div.mkapi-object.generator.top.code,
+div.mkapi-object.method.code,
+div.mkapi-object.method.top.code {
+  color: var(--md-default-fg-color);
+  background-color: var(--md-code-bg-color);
+  border-color: var(--eb-blue);
+  max-width: calc(101% - 4em);
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -189,7 +189,9 @@ div.mkapi-object.function.top.code,
 div.mkapi-object.generator.code,
 div.mkapi-object.generator.top.code,
 div.mkapi-object.method.code,
-div.mkapi-object.method.top.code {
+div.mkapi-object.method.top.code,
+div.mkapi-object.staticmethod.code,
+div.mkapi-object.staticmethod.top.code {
   color: var(--md-default-fg-color);
   background-color: var(--md-code-bg-color);
   border-color: var(--eb-blue);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,12 @@ nav:
   - Release notes: release-notes.md
   - API: api/index.md
   - Getting help: getting-help.md
-  - API: mkapi/api-base/base
+  - API (easybuild.base): mkapi/api-base/base
+  - API (easybuild.framework): mkapi/api-framework/framework
+  # exclude because lots of pages makes "mkdocs serve" take a long time
+  # - API (easybuild.toolchains): mkapi/api-toolchains/toolchains
+  # exclude because it blows up on configobj.py
+  # - API (easybuild.tools): mkapi/api-tools/tools
 
 markdown_extensions:
   # add attributes to html elements
@@ -63,6 +68,9 @@ plugins:
   - git-revision-date-localized:
       exclude:
         - api-base/*
+        - api-framework/*
+        - api-toolchains/*
+        - api-tools/*
   # generate API docs
   - mkapi:
       src_dirs: ["../easybuild-framework/easybuild"]
@@ -72,6 +80,9 @@ plugins:
   - exclude-search:
       exclude:
         - api-base/*
+        - api-framework/*
+        - api-toolchains/*
+        - api-tools/*
   # redirects for original EasyBuild documentation to avoid broken URLs
   - redirects:
       redirect_maps:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
   - Release notes: release-notes.md
   - API: api/index.md
   - Getting help: getting-help.md
+  - API: mkapi/api-base/base
 
 markdown_extensions:
   # add attributes to html elements
@@ -59,9 +60,18 @@ plugins:
   # autolinks across pages
   - autorefs
   # show revision date at bottom of each page
-  - git-revision-date-localized
+  - git-revision-date-localized:
+      exclude:
+        - api-base/*
+  # generate API docs
+  - mkapi:
+      src_dirs: ["../easybuild-framework/easybuild"]
+      filters: [strict]
   # necessary for search to work
   - search
+  - exclude-search:
+      exclude:
+        - api-base/*
   # redirects for original EasyBuild documentation to avoid broken URLs
   - redirects:
       redirect_maps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ mkdocs-material
 mkdocs-redirects
 mkdocs-git-revision-date-localized-plugin
 mkdocs-autorefs
+mkdocs-exclude-search
 mkapi

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mkdocs-material
 mkdocs-redirects
 mkdocs-git-revision-date-localized-plugin
 mkdocs-autorefs
+mkapi


### PR DESCRIPTION
https://github.com/daizutabi/mkapi

Caveats

* Requires `easybuild-framework` source code to be available in sibling directory to `easybuild-docs` **and** installed into the python environment you are using. I have yet to understand why.
* If we include the `tools` directory it blows up.
* If we include the `toolchains` directory it takes ~2 minutes to generate on each save.
* It does not recognise:
   * `:param:`, `:author:`, etc.
   * See https://github.com/branfosj/easybuild-framework/tree/doc for a possible way we could change `easybuild/framework/extension.py`