### PR TITLE
Deal with the missing link warnings

### DIFF
--- a/docs/changelog-docs.md
+++ b/docs/changelog-docs.md
@@ -219,8 +219,7 @@
     documentation and release notes for EasyBuild v3.0.2 (see
     [EasyBuild v3.0.2 (December 22nd 2016)][release_notes_eb302])
 - **release 20161218.01** (*Dec 18th 2016*): document need
-    to download `vsc-*` source tarballs from PyPI (see
-    [bootstrap_offline][bootstrap_offline])
+    to download `vsc-*` source tarballs from PyPI
 - **release 20161202.01** (*Dec 2nd 2016*): add
     documentation on Cray support (see [EasyBuild on Cray][cray_support])
 - **release 20161130.01** (*Nov 16th 2016*): update
@@ -374,8 +373,7 @@
 
 - **release 20150407.01** (*Apr 7th 2015*):
     - add link to [Unit tests][unit_tests] page in
-        dedicated section at [Installing EasyBuild][installation] page (see
-        [install_running_unit_tests][install_running_unit_tests])
+        dedicated section at [Installing EasyBuild][installation] page
     - clarify relation between `--installpath`, `--prefix`,
         `-subdir-*` and `--installpath-*` configuration options (see
         [Software and modules install path][installpath])

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -70,7 +70,7 @@ software name (cfr. [Automagic fallback to ConfigureMake][depr_ConfigureMake_fal
 <!-- XXX - UPDATE BY VERSION FIXME -->
 
 EasyBuild version 2.4.0 includes 154 software-specific easyblocks and 28 generic
-easyblocks (see also [List of easyblocks][basic_usage_easyblocks]), providing support for automatically installing a wide range
+easyblocks (see also [List of easyblocks][vsd_list_easyblocks]), providing support for automatically installing a wide range
 of software packages. Examples range from fairly easy-to-build programs like gzip, other basic tools
 like compilers, various MPI stacks and commonly used libraries, primarily for x86_64 architecture systems,
 to large scientific software packages that are notorious for their involved and tedious install procedures, such as:

--- a/docs/using-easybuild.md
+++ b/docs/using-easybuild.md
@@ -356,7 +356,7 @@ eb HPL-2.3-foss-2021b.eb --debug
 
 !!! tip
 
-   You may enable this by default via adding `debug = True` in your EasyBuild configuration file.
+    You may enable this by default via adding `debug = True` in your EasyBuild configuration file.
 
 !!! note
 

--- a/docs/using-easybuild.md
+++ b/docs/using-easybuild.md
@@ -231,16 +231,119 @@ EasyBuild provides a significant amount of easyconfig parameters.
 An overview of all available easyconfig parameters can be obtained via
 `eb --avail-easyconfig-params`, or `eb -a` for short.
 
-See [available easyconfig parameters][easyconfig_params] for more information,
+See [available easyconfig parameters][vsd_avail_easyconfig_params] for more information,
 the supported parameters are a very rich set.
 
-Combine -a with `--easyblock`/`-e` to include parameters that are specific to a particular easyblock. For example:
+Combine -a with `--easyblock`/`-e` to include parameters that are specific to a particular easyblock.
 
-```shell
-eb -a -e EB_WRF
-```
+??? example "Overview of easyconfig parameters, including those specific to the easyblock for WRF (indicated with (`*`)):"
+    {: #eb_a_e_EB_WRF }
 
-If you want to see the full output of running this command, see [here][eb_a_e_EB_WRF].
+    ```console
+    $ eb -a -e EB_WRF
+
+    Available easyconfig parameters (* indicates specific for the EB_WRF EasyBlock)
+    MANDATORY
+    ---------
+    buildtype(*):         Specify the type of build (serial, smpar (OpenMP), dmpar (MPI), dm+sm (hybrid OpenMP/MPI)). (default: None)
+    description:          A short description of the software (default: None)
+    docurls:              List of urls with documentation of the software (not necessarily on homepage) (default: None)
+    homepage:             The homepage of the software (default: None)
+    name:                 Name of software (default: None)
+    software_license:     Software license (default: None)
+    software_license_urls:        List of software license locations (default: None)
+    toolchain:            Name and version of toolchain (default: None)
+    version:              Version of software (default: None)
+
+    EASYBLOCK-SPECIFIC
+    ------------------
+    rewriteopts(*):       Replace -O3 with CFLAGS/FFLAGS (default: True)
+    runtest(*):           Build and run WRF tests (default: True)
+
+    TOOLCHAIN
+    ---------
+    onlytcmod:            Boolean/string to indicate if the toolchain should only load the environment with module (True) or also set all other variables (False) like compiler CC etc (if string: comma separated list of variables that will be ignored). (default: False)
+    toolchainopts:        Extra options for compilers (default: None)
+
+    BUILD
+    -----
+    buildopts:            Extra options passed to make step (default already has -j X) (default: )
+    checksums:            Checksums for sources and patches (default: [])
+    configopts:           Extra options passed to configure (default already has --prefix) (default: )
+    easyblock:            EasyBlock to use for building (default: ConfigureMake)
+    easybuild_version:    EasyBuild-version this spec-file was written for (default: None)
+    installopts:          Extra options for installation (default: )
+    maxparallel:          Max degree of parallelism (default: None)
+    parallel:             Degree of parallelism for e.g. make (default: based on the number of cores, active cpuset and restrictions in ulimit) (default: None)
+    patches:              List of patches to apply (default: [])
+    postinstallcmds:      Commands to run after the install step. (default: [])
+    prebuildopts:         Extra options pre-passed to build command. (default: )
+    preconfigopts:        Extra options pre-passed to configure. (default: )
+    preinstallopts:       Extra prefix options for installation. (default: )
+    runtest(*):           Indicates if a test should be run after make; should specify argument after make (for e.g.,"test" for make test) (default: None)
+    sanity_check_commands:        format: [(name, options)] e.g. [('gzip','-h')]. Using a non-tuple is equivalent to (name, '-h') (default: [])
+    sanity_check_paths:   List of files and directories to check (format: {'files':<list>, 'dirs':<list>}) (default: {})
+    skip:                 Skip existing software (default: False)
+    skipsteps:            Skip these steps (default: [])
+    source_urls:          List of URLs for source files (default: [])
+    sources:              List of source files (default: [])
+    stop:                 Keyword to halt the build process after a certain step. (default: None)
+    tests:                List of test-scripts to run after install. A test script should return a non-zero exit status to fail (default: [])
+    unpack_options:       Extra options for unpacking source (default: None)
+    unwanted_env_vars:    List of environment variables that shouldn't be set during build (default: [])
+    versionprefix:        Additional prefix for software version (placed before version and toolchain name) (default: )
+    versionsuffix:        Additional suffix for software version (placed after toolchain name) (default: )
+
+    FILE-MANAGEMENT
+    ---------------
+    buildininstalldir:    Boolean to build (True) or not build (False) in the installation directory (default: False)
+    cleanupoldbuild:      Boolean to remove (True) or backup (False) the previous build directory with identical name or not. (default: True)
+    cleanupoldinstall:    Boolean to remove (True) or backup (False) the previous install directory with identical name or not. (default: True)
+    dontcreateinstalldir: Boolean to create (False) or not create (True) the install directory (default: False)
+    keeppreviousinstall:  Boolean to keep the previous installation with identical name. Experts only! (default: False)
+    keepsymlinks:         Boolean to determine whether symlinks are to be kept during copying or if the content of the files pointed to should be copied (default: False)
+    start_dir:            Path to start the make in. If the path is absolute, use that path. If not, this is added to the guessed path. (default: None)
+
+    DEPENDENCIES
+    ------------
+    allow_system_deps:    Allow listed system dependencies (format: (<name>, <version>)) (default: [])
+    builddependencies:    List of build dependencies (default: [])
+    dependencies:         List of dependencies (default: [])
+    hiddendependencies:   List of dependencies available as hidden modules (default: [])
+    osdependencies:               OS dependencies that should be present on the system (default: [])
+
+    LICENSE
+    -------
+    group:                Name of the user group for which the software should be available (default: None)
+    key:                  Key for installing software (default: None)
+    license_file:         License file for software (default: None)
+    license_server:       License server for software (default: None)
+    license_server_port:  Port for license server (default: None)
+
+    EXTENSIONS
+    ----------
+    exts_classmap:        Map of extension name to class for handling build and installation. (default: {})
+    exts_defaultclass:    List of module for and name of the default extension class (default: None)
+    exts_filter:          Extension filter details: template for cmd and input to cmd (templates for name, version and src). (default: None)
+    exts_list:            List with extensions added to the base installation (default: [])
+
+    MODULES
+    -------
+    include_modpath_extensions: Include $MODULEPATH extensions specified by module naming scheme. (default: True)
+    modaliases:           Aliases to be defined in module file (default: {})
+    modextrapaths:        Extra paths to be prepended in module file (default: {})
+    modextravars:         Extra environment variables to be added to module file (default: {})
+    modloadmsg:           Message that should be printed when generated module is loaded (default: {})
+    modtclfooter:         Footer to include in generated module file (Tcl syntax) (default: )
+    moduleclass:          Module class to be used for this software (default: base)
+    moduleforceunload:    Force unload of all modules when loading the extension (default: False)
+    moduleloadnoconflict: Don't check for conflicts, unload other versions instead  (default: False)
+
+    OTHER
+    -----
+    buildstats:           A list of dicts with build statistics (default: None)
+    ```
+
 
 
 ### Enable debug logging

--- a/docs/using-easybuild.md
+++ b/docs/using-easybuild.md
@@ -238,7 +238,7 @@ Combine -a with `--easyblock`/`-e` to include parameters that are specific to a 
 
 ??? example "Overview of easyconfig parameters, including those specific to the easyblock for WRF (indicated with (`*`)):"
 
-    ```console
+    ``` {: .console #eb_a_e_EB_WRF }
     $ eb -a -e EB_WRF
 
     Available easyconfig parameters (* indicates specific for the EB_WRF EasyBlock)
@@ -342,7 +342,6 @@ Combine -a with `--easyblock`/`-e` to include parameters that are specific to a 
     -----
     buildstats:           A list of dicts with build statistics (default: None)
     ```
-    {: #eb_a_e_EB_WRF }
 
 
 ### Enable debug logging

--- a/docs/using-easybuild.md
+++ b/docs/using-easybuild.md
@@ -237,7 +237,6 @@ the supported parameters are a very rich set.
 Combine -a with `--easyblock`/`-e` to include parameters that are specific to a particular easyblock.
 
 ??? example "Overview of easyconfig parameters, including those specific to the easyblock for WRF (indicated with (`*`)):"
-    {: #eb_a_e_EB_WRF }
 
     ```console
     $ eb -a -e EB_WRF
@@ -343,7 +342,7 @@ Combine -a with `--easyblock`/`-e` to include parameters that are specific to a 
     -----
     buildstats:           A list of dicts with build statistics (default: None)
     ```
-
+    {: #eb_a_e_EB_WRF }
 
 
 ### Enable debug logging

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,7 +125,7 @@ plugins:
         en/latest/demos/index.html: demos/index.md
         en/latest/demos/review_pr.html: demos/review-pr.md
         en/latest/eb_a.html: using-easybuild.md#all-available-easyconfig-parameters
-        en/latest/eb_a_e_EB_WRF.html: version-specific/eb-a-wrf.md
+        en/latest/eb_a_e_EB_WRF.html: using-easybuild.md#eb_a_e_EB_WRF
         en/latest/eb_help.html: version-specific/eb-help.md
         en/latest/eb_list_easyblocks.html: version-specific/eb-list-easyblocks.md
         en/latest/eb_list_toolchains.html: version-specific/eb-list-toolchains.md


### PR DESCRIPTION
* Remove `bootstrap_offline` and `install_running_unit_tests` from `changelog-docs.md`. These both are from removed pages
* `basic_usage_easyblocks` is being collapsed into `vsd_list_easyblocks`
* Add the `eb -a -e WRF` example (and so `eb_a_e_EB_WRF`) into the page where it is mentioned
