### PR TITLE
use the main branch of the framework code to generate API docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           repository: easybuilders/easybuild-framework
           path: src/easybuild-framework
+          ref: main
 
       - name: install mkdocs
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           repository: easybuilders/easybuild-framework
           path: src/easybuild-framework
+          ref: main
 
       - name: install mkdocs
         run: |


### PR DESCRIPTION
This is so the deployed site uses the latest release and not the latest develop.