### PR TITLE
add CNAME file to use custom domain for hosting EasyBuild docs

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docsmd.easybuild.io


### PR DESCRIPTION
mkdocs will pick up on `docs/CNAME` when deploying the docs to the `gh-pages` branch, see also https://www.mkdocs.org/user-guide/deploying-your-docs/#custom-domains

For now, we're using `docsmd.easybuild.io` here, so https://docsmd.easybuild.io works as expected, until the new docs are fully ready to replace https://docs.easybuild.io .