### PR TITLE
Remove automatic 'Last update' from index page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,6 +160,7 @@ plugins:
       exclude:
         - api/easybuild/*
         - api/summary.md
+        - index.md
   # necessary for search to work
   - search
   # redirects for original EasyBuild documentation to avoid broken URLs


### PR DESCRIPTION
Currently we have both
```
(last update: 2023-01-17 - [easybuild-docs commit 339da88](https://github.com/easybuilders/easybuild-docs/commits/339da88))
```
and
```
Last update: January 17, 2023
```

This removes the second of those.