### PR TITLE
enhance documentation of `checksums` easyconfig parameter

### DIFF
--- a/docs/writing-easyconfig-files.md
+++ b/docs/writing-easyconfig-files.md
@@ -258,7 +258,7 @@ checksums = [('sha512', 'f962008105639f58e9a4455c8057933ab0a5e2f43db8340ae1e1afe
 
 It is also possible to specify alternative checksums using a tuple of
 checksum elements where any match is sufficient (logical OR).
-This is helpful when the release was updated but can still be used
+This is helpful when the release was updated with changes that don't affect the behavior of the software in any way
 (e.g. only doc changes).
 
 ``` python
@@ -270,12 +270,13 @@ A list instead of a tuple denotes that **all** checksums must match (logical AND
 In both cases each element can also be a type-value-tuple:
 
 ``` python
-checksums = [[('size', 42), 'sha256checksum')]  # Placeholder used
+checksums = [[('size', 42), 'sha256checksum']]  # Placeholder used
 ```
 
-Finally a checksum can be specified as a dictionary mapping filenames to checksums.
-This is useful when the source file is specified using e.g. the `%(arch)s` template.
-Again elements (values) can be strings or type-value-tuples.
+Finally, a checksum can be specified as a dictionary mapping filenames to checksums, removing any ambiguity.
+This style is used by Easybuild with `eb --inject-checksums` when 2 or more source files are specified.
+This style is also useful when the source file is specified using e.g. the `%(arch)s` template.
+Again, elements (values) can be strings or type-value-tuples.
 For example:
 ``` python
 checksums = [{
@@ -293,7 +294,7 @@ checksums = [{
 ```
 
 When the checksum cannot be specified for a file
-(e.g. when using a git clone instead of an archive)
+(e.g. when using a git clone instead of an archive),
 a value of `None` can be used to skip the checksum check.
 This is possible in the list of checksums as well as as a value in a dictionary, e.g.:
 ``` python

--- a/docs/writing-easyconfig-files.md
+++ b/docs/writing-easyconfig-files.md
@@ -312,9 +312,9 @@ checksums = [
 ]
 ```
 
-The difference between having an entry in the dict with the value of `None` and not having an entry
-only matters when using the `--enforce_checksums` option which will raise an error in the latter case.
-
+Note that not having an entry in the dict for a file will raise an error
+while a value of `None` will skip the checksum verification for that file.
+But even in the latter case the `--enforce_checksums` option will raise an error.
 
 ##### Adding or replacing checksums using `--inject-checksums` {: #inject_checksums }
 

--- a/docs/writing-easyconfig-files.md
+++ b/docs/writing-easyconfig-files.md
@@ -232,8 +232,7 @@ highly recommended.
 If checksums are provided, the checksum of the corresponding source
 files and patches is verified to match.
 
-The `checksums` easyconfig parameter is usually defined as a list of
-strings.
+The `checksums` easyconfig parameter is a list usually containing strings.
 
 Until EasyBuild v3.3.0, only MD5 checksums could be provided through a
 list of strings. Since EasyBuild v3.3.0, the checksum type is determined
@@ -256,6 +255,61 @@ example:
 ``` python
 checksums = [('sha512', 'f962008105639f58e9a4455c8057933ab0a5e2f43db8340ae1e1afe6dc2d24105bfca3b2e1f79cb242495ca4eb363c9820d8cea6084df9d62c4c3e5211d99266')]
 ```
+
+It is also possible to specify alternative checksums using a tuple of
+checksum elements where any match is sufficient (logical OR).
+This is helpful when the release was updated but can still be used
+(e.g. only doc changes).
+
+``` python
+checksums = [('mainchecksum', 'alternativechecksum')]  # Placeholders used
+```
+
+The opposite is also possible:
+A list instead of a tuple denotes that **all** checksums must match (logical AND).
+In both cases each element can also be a type-value-tuple:
+
+``` python
+checksums = [[('size', 42), 'sha256checksum')]  # Placeholder used
+```
+
+Finally a checksum can be specified as a dictionary mapping filenames to checksums.
+This is useful when the source file is specified using e.g. the `%(arch)s` template.
+Again elements (values) can be strings or type-value-tuples.
+For example:
+``` python
+checksums = [{
+  'src_x86_64.tgz': 'f962008105639f58e9a4455c8057933ab0a5e2f43db8340ae1e1afe6dc2d2410',
+  'src_aarch64.tgz': ('size', 42),
+}]
+```
+
+Of course this can be combined with the logical AND/OR semantics using lists or tuples:
+``` python
+checksums = [{
+  'src_x86_64.tgz': ('oldchecksum', 'newchecksum'),
+  'src_aarch64.tgz': [('size', 42), 'checksumthatmustmatchtoo'],
+}]
+```
+
+When the checksum cannot be specified for a file
+(e.g. when using a git clone instead of an archive)
+a value of `None` can be used to skip the checksum check.
+This is possible in the list of checksums as well as as a value in a dictionary, e.g.:
+``` python
+checksums = [
+  None, # No checksum for first source file
+  'checksumfor2ndfile',
+  {
+    'third_file_x86_64.tgz': 'checksum',
+    'third_file_aarch64.tgz': None,
+  },
+]
+```
+
+The difference between having an entry in the dict with the value of `None` and not having an entry
+only matters when using the `--enforce_checksums` option which will raise an error in the latter case.
+
 
 ##### Adding or replacing checksums using `--inject-checksums` {: #inject_checksums }
 

--- a/docs/writing-easyconfig-files.md
+++ b/docs/writing-easyconfig-files.md
@@ -262,7 +262,7 @@ This is helpful when the release was updated with changes that don't affect the 
 (e.g. only doc changes).
 
 ``` python
-checksums = [('mainchecksum', 'alternativechecksum')]  # Placeholders used
+checksums = [('0123456789...abcdef', 'fedcba...9876543210')]
 ```
 
 The opposite is also possible:
@@ -270,39 +270,43 @@ A list instead of a tuple denotes that **all** checksums must match (logical AND
 In both cases each element can also be a type-value-tuple:
 
 ``` python
-checksums = [[('size', 42), 'sha256checksum']]  # Placeholder used
+checksums = [[('sha256', '0123456789...abcdef'), 'fedcba...9876543210']]
 ```
 
 Finally, a checksum can be specified as a dictionary mapping filenames to checksums, removing any ambiguity.
-This style is used by Easybuild with `eb --inject-checksums` when 2 or more source files are specified.
-This style is also useful when the source file is specified using e.g. the `%(arch)s` template.
+This style is used by EasyBuild with `eb --inject-checksums` when 2 or more source files are specified,
+and is particularly useful when the source file is specified using a template value like `%(arch)s`.
+Especially when many source files and patches are used this also directly documents the file each checksum is for.  
 Again, elements (values) can be strings or type-value-tuples.
 For example:
+
 ``` python
 checksums = [{
-  'src_x86_64.tgz': 'f962008105639f58e9a4455c8057933ab0a5e2f43db8340ae1e1afe6dc2d2410',
-  'src_aarch64.tgz': ('size', 42),
+  'src_x86_64.tgz': '0123456789...abcdef',
+  'src_aarch64.tgz': ('sha256', 'fedcba...9876543210'),
 }]
 ```
 
 Of course this can be combined with the logical AND/OR semantics using lists or tuples:
+
 ``` python
 checksums = [{
-  'src_x86_64.tgz': ('oldchecksum', 'newchecksum'),
-  'src_aarch64.tgz': [('size', 42), 'checksumthatmustmatchtoo'],
+  'src_x86_64.tgz': ('0123456789...abcdef', 'fedcba...9876543210'), # Match either one
+  'src_aarch64.tgz': [('sha256', '9876543210...fedcba'), 'abcdef...0123456789'], # Match both
 }]
 ```
 
 When the checksum cannot be specified for a file
 (e.g. when using a git clone instead of an archive),
 a value of `None` can be used to skip the checksum check.
-This is possible in the list of checksums as well as as a value in a dictionary, e.g.:
+This is possible in the list of checksums as well as a value in a dictionary, e.g.:
+
 ``` python
 checksums = [
   None, # No checksum for first source file
-  'checksumfor2ndfile',
+  '0123456789...abcdef', # checksum for 2nd file
   {
-    'third_file_x86_64.tgz': 'checksum',
+    'third_file_x86_64.tgz': 'fedcba...9876543210',
     'third_file_aarch64.tgz': None,
   },
 ]
@@ -538,7 +542,7 @@ cannot be automated. Reasons for this include:
 You can use the `download_instructions` parameter to specify steps for
 the user to do. This parameter takes string value and prints it whenever
 build fails because any file needed was not found. If
-`download_instructions` is not specified, Easybuild prints the default
+`download_instructions` is not specified, EasyBuild prints the default
 message stating the paths that were tested.
 
 ``` python


### PR DESCRIPTION
Add more examples of which formats are possible.
Also contains not-yet implemented or broken features!

This is related to https://github.com/easybuilders/easybuild-framework/issues/4142, https://github.com/easybuilders/easybuild-framework/issues/4177, https://github.com/easybuilders/easybuild-framework/pull/4150, https://github.com/easybuilders/easybuild-framework/pull/4159, https://github.com/easybuilders/easybuild-framework/pull/4164

We have https://github.com/easybuilders/easybuild-framework/blob/e3681ae53628400096f3e29d58e787bf1173f27b/test/framework/type_checking.py#L184-L225

and https://github.com/easybuilders/easybuild-framework/blob/e3681ae53628400096f3e29d58e787bf1173f27b/test/framework/type_checking.py#L709-L719

which tests various formats for checksums.

We have code in `get_checksum_for` which supports `checksums` being a dict instead of a list: https://github.com/easybuilders/easybuild-framework/blob/e3681ae53628400096f3e29d58e787bf1173f27b/easybuild/framework/easyblock.py#L369 

However this is not supported by the type-checking code and hence `to_checksums` will be called which would iterate over the dicts keys mistaking them for checksums!!! https://github.com/easybuilders/easybuild-framework/blob/e3681ae53628400096f3e29d58e787bf1173f27b/easybuild/framework/easyconfig/types.py#L475

Furthermore this is made more difficult by the YEB files which use a YAML format where tuples are not supported. E.g. a test file has this:

```
checksums: [[
    'be662daa971a640e40be5c804d9d7d10',  # default [MD5]
    '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',  # default (SHA256)
    ['adler32', '0x998410035'],
    ['crc32', '0x1553842328'],
    ['md5', 'be662daa971a640e40be5c804d9d7d10'],
    ['sha1', 'f618096c52244539d0e89867405f573fdb0b55b0'],
    ['size', 273],
]]
```

This is a checksum entry for a single file. Obviously the inner-most 2-element lists should be converted to tuples and the outer-most list should be a list. But it isn't clear what to do with the 2nd list: Are those alternative checksums where only one needs to match or additional checksums that all need to match? Both cases should be supported.

I would argue that an additional level can be used: `checksums: [[['mainchecksum', 'altchecksum']]]` The type conversion code can deduce that after the 2nd level of lists only tuples may be specified as a list (i.e. an AND) inside a list (already an AND) doesn't make sense, so the 2nd level list is an AND consisting only of a single element, which is redundant but ok.

And finally specifying `None` in a dict currently yields the same error as not specifying it, see https://github.com/easybuilders/easybuild-framework/issues/4142

So things to decide:

- Do we allow `checksums` to be a dict? This would make the base check (`len(checksums) = len(srcs+patches)`) impossible. So I'd keep it a list.
- What do we allow as values of dicts? Should we support the logical AND/OR semantic possible or only strings/type-value-tuples?
- I'd always disallow putting a dict anywhere inside a dict, that's what I did in https://github.com/easybuilders/easybuild-framework/pull/4159 as I see no reason why you'd want that. Or is there any?
- How do we handle `None`? In a tuple it doesn't make sense, so I'd disallow it there. For a dict should we differ between having a key-None entry or not having any entry especially related to `--enforce-checksums`?

I see 2 ways here:

1. dicts can only contain checksums/type-checksum-tuples or None
2. allow full power, so that the value of a dict entry is handled the same as a  "top-level entry" except it disallows more dicts.

As for the missing-key case: ~I'd handle it the same as not specifying it: Error when `enforce_checksums` is active else treat as matched.~ I'd treat it as an error such that typos can be detected as otherwise e.g. `'src_X86_64.tgz'` might be used instead of `'src_x86_64.tgz'` looking valid

Port of https://github.com/easybuilders/easybuild/pull/853 to the new markdown format