### PR TITLE
add missing redirect for Useful_links page in old docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -221,6 +221,7 @@ plugins:
         en/latest/Tracing_progress.html: tracing-progress.md
         en/latest/Typical_workflow_example_with_WRF.html: typical-workflow-example-with-wrf.md
         en/latest/Unit-tests.html: unit-tests.md
+        en/latest/Useful_links.html: index.md
         en/latest/Useful-scripts.html: useful-scripts.md
         en/latest/Using_external_modules.html: using-external-modules.md
         en/latest/Using_the_EasyBuild_command_line.html: using-easybuild.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs
-mkdocs-material
+mkdocs-material==9.0.6
 mkdocs-redirects
 mkdocs-git-revision-date-localized-plugin
 mkdocs-autorefs


### PR DESCRIPTION
I created a sitemap for https://easybuild.readthedocs.io, and this was the only URL we didn't have a redirect for...