### PR TITLE
Remove version pin on mkdocs-material

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs
-mkdocs-material==9.0.6
+mkdocs-material
 mkdocs-redirects
 mkdocs-git-revision-date-localized-plugin
 mkdocs-autorefs


### PR DESCRIPTION
Fixes #110

See https://github.com/oprypin/mkdocs-section-index/releases/tag/v0.3.5