### PR TITLE
skip spellcheck for release notes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           # filter out
           #   docs/js/asciinema-player-2.6.1.js as it is not markdown
           #   version-specific/supported-software.md as the software descriptions have spelling errors
-          skip: './docs/js/asciinema-player-2.6.1.js,./docs/version-specific/supported-software.md'
+          skip: './docs/js/asciinema-player-2.6.1.js,./docs/version-specific/supported-software.md,./docs/release-notes.md'
 
       - name: check internal links
         run: python ./.github/workflows/link_check.py

--- a/docs/python-2-3-compatibility.md
+++ b/docs/python-2-3-compatibility.md
@@ -10,6 +10,9 @@ following Python versions are currently supported:
 - Python 3.6.x
 - Python 3.7.x
 - Python 3.8.x (requires EasyBuild v4.1.0)
+- Python 3.9.x (requires EasyBuild v4.3.1)
+- Python 3.10.x (requires EasyBuild v4.5.2)
+- Python 3.11.x (requires EasyBuild v4.5.2)
 
 ## Determining which Python version EasyBuild is using via `$EB_VERBOSE` {: #py2_py3_compatibility_EB_VERBOSE }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs
-mkdocs-material==9.0.6
+mkdocs-material
 mkdocs-redirects
 mkdocs-git-revision-date-localized-plugin
 mkdocs-autorefs


### PR DESCRIPTION
From https://github.com/easybuilders/easybuild-docs/pull/117#issuecomment-1470043281

It makes sense to skip this as it is an auto-generated page