### PR TITLE
Remove instruction to use plaintext backend for storing GitHub tokens for Unit tests

### DIFF
--- a/docs/unit-tests.md
+++ b/docs/unit-tests.md
@@ -150,7 +150,6 @@ This can be done as follows (copy-paste the GitHub token at the `Password:` prom
 ``` console
 $ python
 >>> import getpass, keyring
->>> keyring.set_keyring(keyring.backends.file.PlaintextKeyring())
 >>> keyring.set_password('github_token', 'easybuild_test', getpass.getpass())
 Password:
 >>> exit()


### PR DESCRIPTION
First of all, it is insecure to store passwords in plain text. It should be discuoraged, not instructed.

Second, `keyring.backends.file.PlaintextKeyring` is no longer part of the keyring API as to discourage insecure storage of passwords. If the developer trying to set up the unit tests tries to follow these instructions verbatim they will fail with the following error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'keyring.backends' has no attribute 'file'
```

If, on my CentOS 7 system, I instead skip straight ahead to setting the password using the next line in the documentation all works out fine.