### PR TITLE
Python 2 compatibility review

### DIFF
--- a/docs/python-2-3-compatibility.md
+++ b/docs/python-2-3-compatibility.md
@@ -5,7 +5,6 @@ compatible with both Python versions 2 and 3. More specifically, the
 following Python versions are currently supported:
 
 - Python 2.6.x (support was removed in EasyBuild v4.4.0)
-- Python 2.7.x (support will be removed in EasyBuild v5.0.0)
 - Python 2.7.x ([support will be removed in EasyBuild v5.0.0](easybuild-v5/overview-of-changes.md))
 - Python 3.5.x ([support will be removed in EasyBuild v5.0.0](easybuild-v5/overview-of-changes.md))
 - Python 3.6.x

--- a/docs/python-2-3-compatibility.md
+++ b/docs/python-2-3-compatibility.md
@@ -5,8 +5,8 @@ compatible with both Python versions 2 and 3. More specifically, the
 following Python versions are currently supported:
 
 - Python 2.6.x (support was removed in EasyBuild v4.4.0)
-- Python 2.7.x
-- Python 3.5.x
+- Python 2.7.x (support will be removed in EasyBuild v5.0.0)
+- Python 3.5.x (support will be removed in EasyBuild v5.0.0)
 - Python 3.6.x
 - Python 3.7.x
 - Python 3.8.x (requires EasyBuild v4.1.0)

--- a/docs/python-2-3-compatibility.md
+++ b/docs/python-2-3-compatibility.md
@@ -6,7 +6,8 @@ following Python versions are currently supported:
 
 - Python 2.6.x (support was removed in EasyBuild v4.4.0)
 - Python 2.7.x (support will be removed in EasyBuild v5.0.0)
-- Python 3.5.x (support will be removed in EasyBuild v5.0.0)
+- Python 2.7.x ([support will be removed in EasyBuild v5.0.0](easybuild-v5/overview-of-changes.md))
+- Python 3.5.x ([support will be removed in EasyBuild v5.0.0](easybuild-v5/overview-of-changes.md))
 - Python 3.6.x
 - Python 3.7.x
 - Python 3.8.x (requires EasyBuild v4.1.0)


### PR DESCRIPTION
https://github.com/easybuilders/easybuild-docs/issues/169

added note that support for python 3.5 and 2.* will be dropped in easybuild 5.0 