### PR TITLE
update hooks documentation to cover new hooks: `pre_build_and_install_loop_hook`, `post_build_and_install_loop_hook`, `pre_postiter_hook`, `post_postiter_hook`, `cancel_hook`, `fail_hook`

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -43,7 +43,7 @@ eb ...
 
 ## Available hooks
 
-Currently (since EasyBuild v3.7.0), five types of hooks are supported:
+Currently, five types of hooks are supported:
 
 * `start_hook`, `pre_build_and_install_loop`, `end_hook` and `post_build_and_install_loop` which are triggered *once* before starting software installations,
   and *once* right after completing all installations, respectively.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -118,7 +118,7 @@ Do take into account the following:
 
 * for `start_hook` and `end_hook`, no arguments are provided
 * for `fail_hook`, `cancel_hook` and `crash_hook`, the exception which caused the build to stop
-is provided
+  is provided
 * for `parse_hook`, one argument is provided: the `EasyConfig` instance
   that corresponds to the easyconfig file being parsed (usually referred to as `ec`)
 * for `pre_build_and_install_loop`, a list of easyconfigs is provided

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -115,6 +115,8 @@ each named after an available hook.
 Do take into account the following:
 
 * for `start_hook` and `end_hook`, no arguments are provided
+* for `fail_hook`, `cancel_hook` and `crash_hook`, the exception which caused the build to stop
+is provided
 * for `parse_hook`, one argument is provided: the `EasyConfig` instance
   that corresponds to the easyconfig file being parsed (usually referred to as `ec`)
 * for `pre_build_and_install_loop`, a list of easyconfigs is provided

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -43,7 +43,7 @@ eb ...
 
 ## Available hooks
 
-Currently (since EasyBuild v3.7.0), three types of hooks are supported:
+Currently (since EasyBuild v3.7.0), five types of hooks are supported:
 
 * `start_hook` and `end_hook`, which are triggered *once* before starting software installations,
   and *once* right after completing all installations, respectively
@@ -59,6 +59,7 @@ which can also be consulted using `eb --avail-hooks`, is:
 
 * `start_hook` *(only called once in an EasyBuild session)*
 * `parse_hook` *(available since EasyBuild v3.7.0)*
+* `pre_build_and_install_loop`
 * `pre_fetch_hook`, `post_fetch_hook`
 * `pre_ready_hook`, `post_ready_hook`
 * `pre_source_hook`, `post_source_hook`
@@ -68,7 +69,9 @@ which can also be consulted using `eb --avail-hooks`, is:
 * `pre_build_hook`, `post_build_hook`
 * `pre_test_hook`, `post_test_hook`
 * `pre_install_hook`, `post_install_hook`
-* `pre_extensions_hook`, `post_extensions_hook`
+* `pre_extensions_hook`
+* `pre_single_extension_hook`, `post_single_extension_hook`
+* `post_extensions_hook`
 * `pre_postproc_hook`, `post_postproc_hook`
 * `pre_sanitycheck_hook`, `post_sanitycheck_hook`
 * `pre_cleanup_hook`, `post_cleanup_hook`
@@ -76,7 +79,11 @@ which can also be consulted using `eb --avail-hooks`, is:
 * `pre_permissions_hook`, `post_permissions_hook`
 * `pre_package_hook`, `post_package_hook`
 * `pre_testcases_hook`, `post_testcases_hook`
+* `post_build_and_install_loop`
 * `end_hook` *(only called once in an EasyBuild session)*
+* `fail_hook`
+* `cancel_hook`
+* `crash_hook`
 * `module_write_hook` *(called multiple times per installation, available since EasyBuild v4.4.1)*
 
 All functions implemented in the provided Python module for which the name ends with `_hook` are considered.
@@ -107,6 +114,8 @@ Do take into account the following:
 * for `start_hook` and `end_hook`, no arguments are provided
 * for `parse_hook`, one argument is provided: the `EasyConfig` instance
   that corresponds to the easyconfig file being parsed (usually referred to as `ec`)
+* for `pre_build_and_install_loop`, a list of easyconfigs is provided
+* for `post_build_and_install_loop`, a list of easyconfigs with build results is provided
 * for `module_write_hook`, 3 arguments are provided:
    * the `EasyBlock` instance used to perform the installation (usually referred to as `self`)
    * the filepath of the module that will be written

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -62,7 +62,7 @@ which can also be consulted using `eb --avail-hooks`, is:
 
 * `start_hook` *(only called once in an EasyBuild session)*
 * `parse_hook` *(available since EasyBuild v3.7.0)*
-* `pre_build_and_install_loop`
+* `pre_build_and_install_loop` *(available since EasyBuild v?)*
 * `pre_fetch_hook`, `post_fetch_hook`
 * `pre_ready_hook`, `post_ready_hook`
 * `pre_source_hook`, `post_source_hook`
@@ -73,8 +73,9 @@ which can also be consulted using `eb --avail-hooks`, is:
 * `pre_test_hook`, `post_test_hook`
 * `pre_install_hook`, `post_install_hook`
 * `pre_extensions_hook`
-* `pre_single_extension_hook`, `post_single_extension_hook`
+* `pre_single_extension_hook`, `post_single_extension_hook` *(available since EasyBuild v4.7.1)*
 * `post_extensions_hook`
+* `pre_postiter_step`, `post_postiter_step`
 * `pre_postproc_hook`, `post_postproc_hook`
 * `pre_sanitycheck_hook`, `post_sanitycheck_hook`
 * `pre_cleanup_hook`, `post_cleanup_hook`
@@ -82,11 +83,11 @@ which can also be consulted using `eb --avail-hooks`, is:
 * `pre_permissions_hook`, `post_permissions_hook`
 * `pre_package_hook`, `post_package_hook`
 * `pre_testcases_hook`, `post_testcases_hook`
-* `post_build_and_install_loop`
+* `post_build_and_install_loop` *(available since EasyBuild v?)*
 * `end_hook` *(only called once in an EasyBuild session)*
-* `fail_hook`
-* `cancel_hook`
-* `crash_hook`
+* `fail_hook` *(available since EasyBuild v?)*
+* `cancel_hook` *(available since EasyBuild v?)*
+* `crash_hook` *(available since EasyBuild v?)*
 * `module_write_hook` *(called multiple times per installation, available since EasyBuild v4.4.1)*
 
 All functions implemented in the provided Python module for which the name ends with `_hook` are considered.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -43,27 +43,26 @@ eb ...
 
 ## Available hooks
 
-Currently, five types of hooks are supported:
+Since EasyBuild v4.8.1, five different types of hooks are supported:
 
-* `start_hook`, `pre_build_and_install_loop`, `post_build_and_install_loop` and `end_hook` which are triggered *once* before starting software
-  installations, *once* before looping over the easyconfigs to be built, *once* after completing the loop over the eayconfigs to be installed,
-  and *once* right after completing all installations, respectively.
+* `start_hook`, `pre_build_and_install_loop_hook`, `post_build_and_install_loop_hook`, and `end_hook` which are triggered *once* right after
+  EasyBuild starts, *once* before looping over the easyconfigs to be built, *once* after completing the loop over the eayconfigs to be installed,
+  and *once* shortly before EasyBuild completes, respectively.
 * `parse_hook`, which is triggered when an easyconfig file is being parsed
 * `module_write_hook`, which is triggered right before a module file is written.
   This includes the temporary module file used when installing extensions and during the sanity check,
   as well as the devel module.
 * "*step*" hooks that are triggered before and after every step of each installation procedure that is performed,
-  also aptly named '`pre`'- and '`post`'- hooks.
-* "*failure*" hooks, `fail_hook`, `cancel_hook`, `crash_hook`, are triggered when an `EasyBuildError`, `KeyboardInterrupt` or `Exception` is 
-  encountered, respectively. `crash_hook` functions as a "catch all" for Python exceptions, and won't be called if either `fail_hook`
-  or `cancel_hook` is run.
+  also aptly named '`pre`'- and '`post`' hooks.
+* `cancel_hook` and `fail_hook` which are triggered when a `KeyboardInterrupt` or `EasyBuildError` is raised,
+  respectively.
 
 The list of currently available hooks in order of execution,
 which can also be consulted using `eb --avail-hooks`, is:
 
 * `start_hook` *(only called once in an EasyBuild session)*
 * `parse_hook` *(available since EasyBuild v3.7.0)*
-* `pre_build_and_install_loop` *(available since EasyBuild v?)*
+* `pre_build_and_install_loop` *(available since EasyBuild v4.8.1)*
 * `pre_fetch_hook`, `post_fetch_hook`
 * `pre_ready_hook`, `post_ready_hook`
 * `pre_source_hook`, `post_source_hook`
@@ -76,7 +75,7 @@ which can also be consulted using `eb --avail-hooks`, is:
 * `pre_extensions_hook`
 * `pre_single_extension_hook`, `post_single_extension_hook` *(available since EasyBuild v4.7.1)*
 * `post_extensions_hook`
-* `pre_postiter_hook`, `post_postiter_hook` *(available since EasyBuild v?)*
+* `pre_postiter_hook`, `post_postiter_hook` *(available since EasyBuild v4.8.1)*
 * `pre_postproc_hook`, `post_postproc_hook`
 * `pre_sanitycheck_hook`, `post_sanitycheck_hook`
 * `pre_cleanup_hook`, `post_cleanup_hook`
@@ -84,11 +83,10 @@ which can also be consulted using `eb --avail-hooks`, is:
 * `pre_permissions_hook`, `post_permissions_hook`
 * `pre_package_hook`, `post_package_hook`
 * `pre_testcases_hook`, `post_testcases_hook`
-* `post_build_and_install_loop` *(available since EasyBuild v?)*
+* `post_build_and_install_loop` *(available since EasyBuild v4.8.1)*
 * `end_hook` *(only called once in an EasyBuild session)*
-* `fail_hook` *(available since EasyBuild v?)*
-* `cancel_hook` *(available since EasyBuild v?)*
-* `crash_hook` *(available since EasyBuild v?)*
+* `cancel_hook` *(available since EasyBuild v4.8.1)*
+* `fail_hook` *(available since EasyBuild v4.8.1)*
 * `module_write_hook` *(called multiple times per installation, available since EasyBuild v4.4.1)*
 
 All functions implemented in the provided Python module for which the name ends with `_hook` are considered.
@@ -117,8 +115,7 @@ each named after an available hook.
 Do take into account the following:
 
 * for `start_hook` and `end_hook`, no arguments are provided
-* for `fail_hook`, `cancel_hook` and `crash_hook`, the exception which caused the build to stop
-  is provided
+* for `cancel_hook` and `fail_hook`, the `KeyboardInterrupt` or `EasyBuildError` exception that was raised is provided
 * for `parse_hook`, one argument is provided: the `EasyConfig` instance
   that corresponds to the easyconfig file being parsed (usually referred to as `ec`)
 * for `pre_build_and_install_loop`, a list of easyconfigs is provided

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -75,6 +75,7 @@ which can also be consulted using `eb --avail-hooks`, is:
 * `pre_extensions_hook`
 * `pre_single_extension_hook`, `post_single_extension_hook` *(available since EasyBuild v4.7.1)*
 * `post_extensions_hook`
+* `pre_postiter_hook`, `post_postiter_hook` *(available since EasyBuild v?)*
 * `pre_postproc_hook`, `post_postproc_hook`
 * `pre_sanitycheck_hook`, `post_sanitycheck_hook`
 * `pre_cleanup_hook`, `post_cleanup_hook`

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -55,8 +55,8 @@ Currently, five types of hooks are supported:
 * "*step*" hooks that are triggered before and after every step of each installation procedure that is performed,
   also aptly named '`pre`'- and '`post`'- hooks.
 * "*failure*" hooks, `fail_hook`, `cancel_hook`, `crash_hook`, are triggered when an `EasyBuildError`, `KeyboardInterrupt` or `Exception` is 
-encountered, respectively. `crash_hook` functions as a "catch all" for Python exceptions, and won't be called if either `fail_hook` or `cancel_hook`
-is run.
+  encountered, respectively. `crash_hook` functions as a "catch all" for Python exceptions, and won't be called if either `fail_hook`
+  or `cancel_hook` is run.
 
 The list of currently available hooks in order of execution,
 which can also be consulted using `eb --avail-hooks`, is:

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -75,7 +75,6 @@ which can also be consulted using `eb --avail-hooks`, is:
 * `pre_extensions_hook`
 * `pre_single_extension_hook`, `post_single_extension_hook` *(available since EasyBuild v4.7.1)*
 * `post_extensions_hook`
-* `pre_postiter_step`, `post_postiter_step`
 * `pre_postproc_hook`, `post_postproc_hook`
 * `pre_sanitycheck_hook`, `post_sanitycheck_hook`
 * `pre_cleanup_hook`, `post_cleanup_hook`

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -45,7 +45,8 @@ eb ...
 
 Currently, five types of hooks are supported:
 
-* `start_hook`, `pre_build_and_install_loop`, `end_hook` and `post_build_and_install_loop` which are triggered *once* before starting software installations,
+* `start_hook`, `pre_build_and_install_loop`, `post_build_and_install_loop` and `end_hook` which are triggered *once* before starting software
+  installations, *once* before looping over the easyconfigs to be built, *once* after completing the loop over the eayconfigs to be installed,
   and *once* right after completing all installations, respectively.
 * `parse_hook`, which is triggered when an easyconfig file is being parsed
 * `module_write_hook`, which is triggered right before a module file is written.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -45,14 +45,17 @@ eb ...
 
 Currently (since EasyBuild v3.7.0), five types of hooks are supported:
 
-* `start_hook` and `end_hook`, which are triggered *once* before starting software installations,
-  and *once* right after completing all installations, respectively
+* `start_hook`, `pre_build_and_install_loop`, `end_hook` and `post_build_and_install_loop` which are triggered *once* before starting software installations,
+  and *once* right after completing all installations, respectively.
 * `parse_hook`, which is triggered when an easyconfig file is being parsed
 * `module_write_hook`, which is triggered right before a module file is written.
   This includes the temporary module file used when installing extensions and during the sanity check,
   as well as the devel module.
 * "*step*" hooks that are triggered before and after every step of each installation procedure that is performed,
-  also aptly named '`pre`'- and '`post`'-hooks
+  also aptly named '`pre`'- and '`post`'- hooks.
+* "*failure*" hooks, `fail_hook`, `cancel_hook`, `crash_hook`, are triggered when an `EasyBuildError`, `KeyboardInterrupt` or `Exception` is 
+encountered, respectively. `crash_hook` functions as a "catch all" for Python exceptions, and won't be called if either `fail_hook` or `cancel_hook`
+is run.
 
 The list of currently available hooks in order of execution,
 which can also be consulted using `eb --avail-hooks`, is:


### PR DESCRIPTION
- Includes failure hooks, as well as `build_and_install_loop` hooks
- Detail information about hook parameters.
- Correct some small typos.
~~- I am unsure about the `postiter` hook and what it does, and whether it even has pre and post variations~~
~~`postiter` seems to be not callable, thus I have remove it.~~
`postiter` will be implemented in a future version, adding to docs...