### PR TITLE
Fix all typos to make test suite happy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true
-          ignore_words_list: atleast,ninjs,simpy,proovread,namd,precice,crate
+          ignore_words_list: atleast,ninjs,simpy,proovread,namd,precice,crate,ake
           # filter out
           #   docs/js/asciinema-player-2.6.1.js as it is not markdown
           #   version-specific/supported-software.md as the software descriptions have spelling errors

--- a/docs/removed-functionality.md
+++ b/docs/removed-functionality.md
@@ -50,7 +50,7 @@ fittingly named `use_fma4` parameter in EasyBuild v3.2.0.
 - *alternatives*: **use** `extract_cmd` **key in Python dictionary
     format instead**
 
-Specyfing a custom extraction command for a particular source file by
+Specifying a custom extraction command for a particular source file by
 using a 2-element tuple in `sources` is no longer supported.
 
 Instead, a Python dictionary containing the `filename` and `extract_cmd`

--- a/docs/version-specific/eb-help.md
+++ b/docs/version-specific/eb-help.md
@@ -283,7 +283,7 @@ Option flag                                                              |Option
 ``--optarch=OPTARCH``                                                    |Set architecture optimization, overriding native architecture optimizations
 ``--output-format=OUTPUT-FORMAT``                                        |Set output format (type choice; default: txt) (choices: md, rst, txt)
 ``--output-style=OUTPUT-STYLE``                                          |Control output style; auto implies using Rich if available to produce rich output, with fallback to basic colored output (type choice; default: auto) (choices: auto, basic, no_color, rich)
-``--parallel=PARALLEL``                                                  |Specify (maximum) level of parallellism used during build procedure (type int)
+``--parallel=PARALLEL``                                                  |Specify (maximum) level of parallelism used during build procedure (type int)
 ``--parallel-extensions-install``                                        |Install list of extensions in parallel (if supported) (default: False)
 ``--pre-create-installdir``                                              |Create installation directory before submitting build jobs (default: True; disable with --disable-pre-create-installdir)
 ``-p, --pretend``                                                        |Does the build/installation in a test directory located in $HOME/easybuildinstall (default: False)

--- a/docs/version-specific/toolchain-opts.md
+++ b/docs/version-specific/toolchain-opts.md
@@ -551,7 +551,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -593,7 +593,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -674,7 +674,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -715,7 +715,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -756,7 +756,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -797,7 +797,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -838,7 +838,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -880,7 +880,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -922,7 +922,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -964,7 +964,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1006,7 +1006,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1048,7 +1048,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1090,7 +1090,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1131,7 +1131,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1172,7 +1172,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1214,7 +1214,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1256,7 +1256,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1298,7 +1298,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1340,7 +1340,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1382,7 +1382,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1424,7 +1424,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1465,7 +1465,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1507,7 +1507,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1549,7 +1549,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1591,7 +1591,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1633,7 +1633,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1674,7 +1674,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1715,7 +1715,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1757,7 +1757,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1799,7 +1799,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1841,7 +1841,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1883,7 +1883,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1925,7 +1925,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -1967,7 +1967,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -2009,7 +2009,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -2051,7 +2051,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -2093,7 +2093,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``
@@ -2135,7 +2135,7 @@ option                   |description                                           
 ``f2c``                  |Generate code compatible with f2c and f77                              |``False``
 ``i8``                   |Integers are 8 byte integers                                           |``False``
 ``ieee``                 |Adhere to IEEE-754 rules                                               |``False``
-``loop``                 |Automatic loop parallellisation                                        |``False``
+``loop``                 |Automatic loop parallelisation                                         |``False``
 ``loose``                |Loose precision                                                        |``False``
 ``lowopt``               |Low compiler optimizations                                             |``False``
 ``lto``                  |Enable Link Time Optimization                                          |``False``


### PR DESCRIPTION
I looked for any syntax errors in the markdown that would make the spell check complain about Åkes name, but it looks correct to me. I have no other option but to exclude it in the check itself so that the test suite passes again.
I think we should just fix this now so that not all the other unrelated PRs fail over this.