### PR TITLE
stick to 2023a for now in toolchain support policy + don't link it to EasyBuild 5.0

### DIFF
--- a/docs/policies/toolchains.md
+++ b/docs/policies/toolchains.md
@@ -25,9 +25,9 @@ collection is added via the [robot search path][robot_search_path].
 
 ## Example
 
-As of November 2023 the latest toolchain generation is `2023b`.
+As of July 2023 (EasyBuild 4.8.0) the latest toolchain generation is `2023a`.
 
-* Supported: 2023b, 2023a, 2022b, 2022a, 2021b, 2021a
-* Deprecated: 2020b and 2020a
-* Archived (and unsupported): 2019b and older
+* Supported: 2023a, 2022b, 2022a, 2021b, 2021a, 2020b
+* Deprecated: 2020a, 2019b
+* Archived (and unsupported): 2019a and older
 

--- a/docs/policies/toolchains.md
+++ b/docs/policies/toolchains.md
@@ -1,8 +1,5 @@
 # Supported Toolchain Generations Policy {: #policy_toolchains }
 
-!!! note
-     This policy will be implemented as part of the release of [EasyBuild 5.0][overview]
-
 For the central EasyBuild repositories, we support a set of toolchain generations.
 
 * Accept PRs only for the 6 most recent toolchain generations.

--- a/docs/policies/toolchains.md
+++ b/docs/policies/toolchains.md
@@ -20,11 +20,10 @@ exceptions, but we aim to keep these limited.)
 Sites and users can then supplement these easyconfigs via there own collection of easyconfigs. This additional
 collection is added via the [robot search path][robot_search_path].
 
-## Example
+## Current situation
 
 As of July 2023 (EasyBuild 4.8.0) the latest toolchain generation is `2023a`.
 
 * Supported: 2023a, 2022b, 2022a, 2021b, 2021a, 2020b
-* Deprecated: 2020a, 2019b
-* Archived (and unsupported): 2019a and older
-
+* Deprecated: 2020a (GCC 9.3.0), 2019b (GCC 8.3.0)
+* Archived (and unsupported): 2019a (GCC 8.2.0), and older


### PR DESCRIPTION
I'm purposely targeting the `main` branch here, because what's currently shown at https://docs.easybuild.io/policies/toolchains/ is not correct since `2023b` does not exist yet (it'll likely be set in stone in Nov'23, but that's not 100% sure).