### PR TITLE
Describe MODULES_CMD env var use to search module tool

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -620,7 +620,9 @@ output of `type -f module` (in a `bash` shell), or `alias module` (in a `tcsh` s
 
 The actual module command (i.e., `modulecmd`, `modulecmd.tcl`,
 `lmod`, ...) must be available via `$PATH` (which is not standard), except when using Lmod
-(in that case the `lmod` binary can also be located via `$LMOD_CMD`).
+(in that case the `lmod` binary can also be located via `$LMOD_CMD`) or when using
+Environment Modules (in that case the `modulecmd.tcl` binary can also be located via
+`$MODULES_CMD`).
 
 For example, to indicate that EasyBuild should be using `Lmod` as modules tool:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -356,11 +356,15 @@ Supported module tools:
     the `module` function; for example, using `type module` or `type -f module`.
 
 !!! note
-    For Lmod specifically, EasyBuild will try to fall back to finding the `lmod` binary via the `$LMOD_CMD`
+    For Lmod, EasyBuild will try to fall back to finding the `lmod` binary via the `$LMOD_CMD`
     environment variable, in case `lmod` is not available in `$PATH`.
 
     In EasyBuild versions *prior* to 2.1.1, the path specified by `$LMOD_CMD` was (erroneously) preferred over the
     (first) `lmod` binary available via `$PATH`.
+
+    For modern Tcl-only environment modules (version >= 4.0.0), EasyBuild will try to fall back to finding the
+    `modulecmd.tcl` binary via the `$MODULES_CMD` environment variable, in case `modulecmd.tcl` is not available
+    in `$PATH`.
 
 
 Additional notes:


### PR DESCRIPTION
When using EnvironmentModules as module tool, the modulecmd.tcl binary is now also searched with "$MODULES_CMD" environment variable, like done for Lmod with "$LMOD_CMD".