### PR TITLE
Fix wording in allowed sources keys

### DIFF
--- a/docs/writing-easyconfig-files.md
+++ b/docs/writing-easyconfig-files.md
@@ -443,7 +443,7 @@ filename that should be used to download the source file.
 This can be specified using a Python dictionary value in the `sources`
 easyconfig parameter.
 
-Since EasyBuild v3.3.0, three keys are supported:
+The following keys are supported:
 
 - `filename` (*mandatory*): filename of source file
 - `download_filename`: filename that should be used when downloading


### PR DESCRIPTION
The allowed keys are more then three.
e.g. `git_config wasn't available until 3.7