### PR TITLE
Fix URL to libvdwxc as the old address had been taken over by evildoers.

### DIFF
--- a/docs/version-specific/supported-software/l/libvdwxc.md
+++ b/docs/version-specific/supported-software/l/libvdwxc.md
@@ -6,7 +6,7 @@ search:
 
 libvdwxc is a general library for evaluating energy and potential for exchange-correlation (XC) functionals from the vdW-DF family that can be used with various of density functional theory (DFT) codes.
 
-*homepage*: <http://libvdwxc.org>
+*homepage*: <https://libvdwxc.materialsmodeling.org/>
 
 version | toolchain
 --------|----------


### PR DESCRIPTION
Update the URL to libvdwxc since the old URL has been taken over by evildoers, who place an add to a financial scam on the page.  The same change has been done to the URLs in the EasyBlocks in https://github.com/easybuilders/easybuild-easyconfigs/pull/21797, but there is a link in the docs, too.

CC: @askhl
