### PR TITLE
stop using navigation integration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,6 @@ theme:
     - navigation.top
     - navigation.tracking
     - toc.follow
-    - toc.integrate
     # https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search
     - search.highlight
     - search.suggest


### PR DESCRIPTION
Not using `toc.integrate` implies that the table of contents of a page is shown in a sidebar on the right, rather than being integrated in the menu on the left.

A small downside of that is that the body of the documentation in the middle is less wide, but perhaps that's not a bad thing (shorter line make for easier reading).

The Materials for MkDocs documentation nicely shows an example of the effect, see https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-integration

The main motivation for this to make the menu on the left a bit less daunting, and pages which do not have a menu entry on the left (like https://docs.easybuild.io/easybuild-v5/backwards-incompatible-changes/ for example)