### PR TITLE
disable table-of-contents sidebar on landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 # EasyBuild Documentation
 
 ---


### PR DESCRIPTION
required to fix fallout of landing page becoming narrower due to #287