### PR TITLE
fix broken link to changes in easybuild 5.0

### DIFF
--- a/docs/easybuild-v5/changes.md
+++ b/docs/easybuild-v5/changes.md
@@ -6,8 +6,8 @@ The default value for several EasyBuild configuration settings has been changed 
 
 **Changed default configuration in EasyBuild framework**
 
-- [RPATH linking is enabled by default (`--rpath`)][path]
-- [Trace output is enabled by default (`--trace`)][trace)]
+- [RPATH linking is enabled by default (`--rpath`)][rpath]
+- [Trace output is enabled by default (`--trace`)][trace]
 - [Including `extensions` statement in generated modules is enabled by default (`--module-extensions`)][module-extensions]
 - [Using `depends_on` for dependencies in generated modules is enabled by default (`module-depends-on`)][module-depends-on]
 - [Use Slurm as default job backend (`--job-backend`)][job-backend]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,7 +132,7 @@ nav:
       - (overview): easybuild-v5/index.md
       - Enhancements in EasyBuild v5.0: easybuild-v5/enhancements.md
       - Run shell commands function (`run_shell_cmd`): easybuild-v5/run_shell_cmd.md
-      - Changes in default configuration in EasyBuild v5.0: easybuild-v5/changes-in-default-configuration.md
+      - Changes in default configuration in EasyBuild v5.0: easybuild-v5/changes.md
       - Deprecated functionality in EasyBuild v5.0: easybuild-v5/deprecated-functionality.md
       - Removed functionality in EasyBuild v5.0: easybuild-v5/removed-functionality.md
       - Known issues in EasyBuild v5.0: easybuild-v5/known-issues.md


### PR DESCRIPTION
The sidebar has a broken link to https://docs.easybuild.io/easybuild-v5/changes-in-default-configuration.md and the TOC of that document has a few broken links as well.