### PR TITLE
remove section about allowing missing easyblocks in parallel extensions

### DIFF
--- a/docs/easybuild-v5/enhancements.md
+++ b/docs/easybuild-v5/enhancements.md
@@ -6,7 +6,6 @@ Various significant enhancements are included in EasyBuild v5.0, including:
 
 - [New function to run shell commands: `run_shell_cmd`][run_shell_cmd]
 - [Interactive debugging of failing shell commands via `env.sh` and `cmd.sh` scripts][interactive-debugging-failing-shell-commands]
-- [Don't raise error when required extensions are not found when installing extensions in parallel][parallel-extensions-install]
 - [Mark support for installing extensions in parallel as stable (no longer experimental)][parallel-extensions-install-stable]
 - [Mark easystack support as stable (no longer experimental)][easystack-stable]
 - [Reproducible tarballs for sources created via `git_config`][reproducible-tarballs-git_config]
@@ -51,13 +50,6 @@ codes from external processes executed through `run_shell_cmd` or HTTP response
 status codes are reported in the corresponding logs.
 
 ---
-
-## Don't raise error when required extensions are not found when installing extensions in parallel {: #parallel-extensions-install }
-
-*(more info soon)*
-
----
-
 
 ## Mark support for installing extensions in parallel as stable (no longer experimental) {: #parallel-extensions-install-stable }
 

--- a/docs/easybuild-v5/index.md
+++ b/docs/easybuild-v5/index.md
@@ -67,7 +67,6 @@ Various significant enhancements are included in EasyBuild v5.0, including:
 
 - [New function to run shell commands: `run_shell_cmd`](run_shell_cmd.md)
 - [Interactive debugging of failing shell commands via `env.sh` and `cmd.sh` scripts](../interactive-debugging-failing-shell-commands.md)
-- [Don't raise error when required extensions are not found when installing extensions in parallel](enhancements.md#parallel-extensions-install)
 - [Mark support for installing extensions in parallel as stable (no longer experimental)](enhancements.md#parallel-extensions-install-stable)
 - [Mark easystack support as stable (no longer experimental)](enhancements.md#easystack-stable)
 - [Reproducible tarballs for sources created via `git_config`](enhancements.md#reproducible-tarballs-git_config)


### PR DESCRIPTION
This seems too much of a detail to be its own section. I would document the removal of this error in the section about the stabilization of parallel extensions.