### PR TITLE
update documentation about deprecated and archived easyconfigs

### DIFF
--- a/docs/archived-easyconfigs.md
+++ b/docs/archived-easyconfigs.md
@@ -3,54 +3,66 @@
 Since EasyBuild v3.0.0, easyconfig files using deprecated (i.e., old and
 inactive) toolchains are *archived*.
 
+Since EasyBuild v5.0.0, archived easyconfig files are transferred to the
+[easybuild-easyconfigs-archive](https://github.com/easybuilders/easybuild-easyconfigs-archive)
+repository.
+
 ## Toolchain deprecation {: #archived_easyconfigs_toolchain_deprecation }
 
-Once in a blue moon, we review the list of toolchains (& versions) that
-are included in EasyBuild.
+Support for toolchains included in EasyBuild is defined in our
+[support policy on toolchain generations][policy_toolchains].
 
-Easyconfig files that use toolchains that become *deprecated* are then
-moved to the *easyconfigs archive*, i.e. the `__archive__` subdirectory
-in the `easybuild-easyconfigs` repository (see
-<https://github.com/easybuilders/easybuild-easyconfigs/tree/main/easybuild/easyconfigs/__archive__>).
+Once a new toolchain generation is released, it will be supported by the
+maintainers of Easybuild for a limited period of time. Afterwards, it becomes
+deprecated and at some point it will be archived including all easyconfig files
+using that toolchain.
 
 ### What are deprecated toolchains? {: #archived_easyconfigs_deprecated_toolchains_what }
 
-Toolchains become deprecated if:
+A deprecated toolchain is a toolchain version or generation that is no longer
+recommended for use in production systems.
 
-- no easyconfig files using that toolchain have been contributed
-  recently (e.g., in the last year)
-- that toolchain is considered to be inactive, after consulting the
-  EasyBuild community (via mailing list, bi-weekly conf calls)
+Initially, deprecated toolchains are removed from the EasyBuild regression
+tests and new contributions in the form of easyconfigs become restricted.
+After a period of time defined in our [support policy][policy_toolchains],
+all easyconfig files using that deprecated toolchain are moved to the
+*easyconfigs archive*, i.e. the `__archive__` subdirectory in the
+[easybuild-easyconfigs-archive](https://github.com/easybuilders/easybuild-easyconfigs-archive)
+repository.
 
-Deprecating a toolchain implies that all easyconfigs using that
-toolchain are moved to the easyconfigs archive, and that they are no
-longer included in the EasyBuild regression test. In addition, these
-easyconfigs are 'hidden' from plain sight, in the sense that you need to
-use `--consider-archived-easyconfigs` to make EasyBuild consider them
-when it is looking for easyconfigs (e.g., with `--search` or
-`--robot`).
-
-This does *not* mean that the support for using these toolchains is
-removed from the EasyBuild framework, although not testing them anymore
+This does *not* mean that the support for using deprecated toolchains is
+removed from the EasyBuild framework, although the lack of testing
 may imply that using them may no longer work at some point in time.
-
-For toolchains for which no active versions are available (outside of
-the easyconfigs archive), it is possible that they will be reactivated,
-if a new toolchain version is contributed.
 
 ### Why are toolchains being deprecated? {: #archived_easyconfigs_deprecated_toolchains_why }
 
-- using old toolchains (incl. old compilers and/or libraries) is
-  likely to become more and more difficult on modern operating systems
-- these toolchains put a significant burden on the regression testing
-  for EasyBuild releases
-- easyconfigs using old toolchains are likely to be for old software
-  versions, which may no longer be relevant anyway
+Toolchain generations are deprecated if:
 
-## Using `--consider-archived-easyconfigs` {: #archived_easyconfigs_consider }
+- it is established in our [support policy][policy_toolchains]
+- they become inactive, meaning that no easyconfig files using that toolchain
+  have been contributed for a long period of time (e.g., in the last year)
+- they become [obsolete][obsolete_easyconfigs_toolchains], which usually
+  happens when a toolchain is replaced by some other newer toolchain
 
-To make EasyBuild consider archived easyconfig files, you need to enable
-the `--consider-archived-easyconfigs` configuration option:
+Inactive toolchains may become re-activated in the future if a new toolchain
+version is contributed to `easybuild-easyconfigs`.
+
+## Using archived easyconfigs {: #use_archived_easyconfigs }
+
+The archive of easyconfigs is not installed by default. You need to install the
+`easybuild-easyconfigs` package with the `archive` extra option in `pip`. This
+will pull in the `easybuild-easyconfigs-archive` package, which provides the
+contents of the `__archive__` subdirectory.
+
+```shell
+python -m pip install easybuild-easyconfigs[archive]
+```
+
+Easyconfig files in the archive are _hidden_ from plain sight, meaning that the
+`eb` command will not use those files by default. You need to use the
+`--consider-archived-easyconfigs` configuration option to make EasyBuild look
+into the archive when it seeks easyconfigs (e.g., with `--search` or
+`--robot`).
 
 ``` console
 $ eb -S '^goolfc'

--- a/docs/common-toolchains.md
+++ b/docs/common-toolchains.md
@@ -153,11 +153,16 @@ available in [Overview of common toolchains][common_toolchains_overview].
 
 The intention is to revise and update the common toolchains every 6
 months: once in late December/early January (version `<year>a`), and
-once in late June/early July (version `<year>b`).
+once in late June/early July (version `<year>b`). Each one of these
+versions is a so-called _toolchain generation_.
 
-This is meant be to be a community effort, in the sense that a proposal
-for an updated composition is shared and discussed before it is set in
-stone.
+Each new version is meant be to be a community effort, in the sense that a
+proposal for an updated composition is shared and discussed before it is set in
+stone. Usually, discussion about new toolchains takes place initially in the
+[toolchain-wg](https://easybuild.slack.com/archives/C02FU5Y5CDT) in Slack, the
+bi-weekly conf calls and later in respective pull requests in the
+[easybuild-easyconfigs](https://github.com/easybuilders/easybuild-easyconfigs)
+repository.
 
 Recent versions of each of the toolchain components are considered,
 taking into account stability, performance improvements, added features,
@@ -167,71 +172,69 @@ Moreover, the proposed toolchain compositions are tested extensively,
 typically by rebuilding all available easyconfigs that are using the
 most recent revision of the common toolchains at that time.
 
+Once a new toolchain generation is released, it will be supported by the
+maintainers of Easybuild for a limited period of time. Which is determined by
+our [support policy on toolchain][policy_toolchains].
+
 ## Overview of common toolchains {: #common_toolchains_overview }
+
+We support the [last 6 generations][policy_toolchains] of common toolchains.
+
+Archived toolchains can be found in the
+[easybuild-easyconfigs-archive](https://github.com/easybuilders/easybuild-easyconfigs-archive)
+repository.
 
 ### Component versions in `foss` toolchain {: #common_toolchains_overview_foss }
 
-| `foss`  | *date*   | *binutils* | *GCC*  | *Open MPI* | *FlexiBLAS* | *OpenBLAS* | *LAPACK*               | *ScaLAPACK* | *FFTW* |
-|---------|----------|------------|--------|------------|-------------|------------|------------------------|-------------|--------|
-| `2021a` | May '21  | 2.36.1     | 10.3.0 | 4.1.1      | 3.0.4       | 0.3.15     | (incl. with FlexiBLAS) | 2.1.0       | 3.3.9  |
-| `2021b` | Oct '21  | 2.37       | 11.2.0 | 4.1.1      | 3.0.4       | 0.3.18     | (incl. with FlexiBLAS) | 2.1.0       | 3.3.10 |
-| `2022a` | Jun '22  | 2.38       | 11.3.0 | 4.1.4      | 3.2.0       | 0.3.20     | (incl. with FlexiBLAS) | 2.2.0       | 3.3.10 |
-| `2022b` | Dec '22  | 2.39       | 12.2.0 | 4.1.4      | 3.2.1       | 0.3.21     | (incl. with FlexiBLAS) | 2.2.0       | 3.3.10 |
-| `2023a` | Jun '23  | 2.40       | 12.3.0 | 4.1.5      | 3.3.1       | 0.3.23     | (incl. with FlexiBLAS) | 2.2.0       | 3.3.10 |
-| `2023b` | Dec '23  | 2.40       | 13.2.0 | 4.1.6      | 3.3.1       | 0.3.24     | (incl. with FlexiBLAS) | 2.2.0       | 3.3.10 |
-| `2024a` | Aug '24  | 2.42       | 13.3.0 | 5.0.3      | 3.4.4       | 0.3.27     | (incl. with FlexiBLAS) | 2.2.0       | 3.3.10 |
-
-### Component versions in `intel` toolchain {: #common_toolchains_overview_intel }
-
-| `intel` | *date*   | *binutils* | *GCC*  | *Intel compilers* | *Intel MPI* | *Intel MKL* |
-|---------|----------|------------|--------|-------------------|-------------|-------------|
-| `2021a` | May '21  | 2.36.1     | 10.3.0 | 2021.2.0          | 2021.2.0    | 2021.2.0    |
-| `2021b` | Oct '21  | 2.37       | 11.2.0 | 2021.4.0          | 2021.4.0    | 2021.4.0    |
-| `2022a` | Jun '22  | 2.38       | 11.3.0 | 2022.1.0          | 2021.6.0    | 2022.1.0    |
-| `2022b` | Dec '22  | 2.39       | 12.2.0 | 2022.2.1          | 2021.7.1    | 2022.2.1    |
-| `2023a` | Jun '23  | 2.40       | 12.3.0 | 2023.1.0          | 2021.9.1    | 2023.1.0    |
-| `2023b` | Dec '23  | 2.40       | 13.2.0 | 2023.2.1          | 2021.10.1   | 2023.2.0    |
-| `2024a` | Aug '24  | 2.42       | 13.3.0 | 2024.2.0          | 2021.13.0   | 2024.2.0    |
-
-## Overview of common toolchains (deprecated versions) {: #common_toolchains_overview_deprecated }
-
-### Component versions in `foss` toolchain (deprecated versions) {: #common_toolchains_overview_foss_deprecated }
-
-| `foss`  | *date*   | *binutils* | *GCC*  | *Open MPI* | *FlexiBLAS* | *OpenBLAS* | *LAPACK*               | *ScaLAPACK* | *FFTW*      |
-|---------|----------|------------|--------|------------|-------------|------------|------------------------|-------------|-------------|
-| `2014b` | Jul '14  | '*(none)*  | 4.8.3  | 1.8.1      | *(none)*    | 0.2.9      | 3.5.0                  | 2.0.2       | 3.3.4       |
-| `2015a` | Jan '15  | '*(none)*  | 4.9.2  | 1.8.4      | *(none)*    | 0.2.13     | 3.5.0                  | 2.0.2       | 3.3.4       |
-| `2015b` | Jul '15  | 2.25       | 4.9.3  | 1.8.8      | *(none)*    | 0.2.14     | 3.5.0                  | 2.0.2       | 3.3.4       |
-| `2016a` | Jan '16  | 2.25       | 4.9.3  | 1.10.2     | *(none)*    | 0.2.15     | 3.6.0                  | 2.0.2       | 3.3.4       |
-| `2016b` | Jul '16  | 2.26       | 5.4.0  | 1.10.3     | *(none)*    | 0.2.18     | 3.6.1                  | 2.0.2       | 3.3.4       |
-| `2017a` | Jan '17  | 2.27       | 6.3.0  | 2.0.2      | *(none)*    | 0.2.19     | 3.7.0                  | 2.0.2       | 3.3.6(-pl2) |
-| `2017b` | Jul '17  | 2.28       | 6.4.0  | 2.1.1      | *(none)*    | 0.2.20\*   | (incl. with OpenBLAS)  | 2.0.2       | 3.3.6(-pl2) |
-| `2018a` | Jan '18  | 2.28       | 6.4.0  | 2.1.2      | *(none)*    | 0.2.20\*   | (incl. with OpenBLAS)  | 2.0.2       | 3.3.7       |
-| `2018b` | Jul '18  | 2.30       | 7.3.0  | 3.1.1      | *(none)*    | 0.3.1      | (incl. with OpenBLAS)  | 2.0.2       | 3.3.8       |
-| `2019a` | Jan '19  | 2.31.1     | 8.2.0  | 3.1.3      | *(none)*    | 0.3.5      | (incl. with OpenBLAS)  | 2.0.2       | 3.3.8       |
-| `2019b` | Sept '19 | 2.32       | 8.3.0  | 3.1.4      | *(none)*    | 0.3.7      | (incl. with OpenBLAS)  | 2.0.2       | 3.3.8       |
-| `2020a` | May '20  | 2.34       | 9.3.0  | 4.0.3      | *(none)*    | 0.3.9      | (incl. with OpenBLAS)  | 2.1.0       | 3.3.8       |
-| `2020b` | Nov '20  | 2.35       | 10.2.0 | 4.0.5      | *(none)*    | 0.3.12     | (incl. with OpenBLAS)  | 2.1.0       | 3.3.8       |
+| `foss`  | *support*  | *date*   | *binutils* | *GCC*  | *Open MPI* | *FlexiBLAS* | *OpenBLAS* | *LAPACK*               | *ScaLAPACK* | *FFTW*      |
+|---------|------------|----------|------------|--------|------------|-------------|------------|------------------------|-------------|-------------|
+| `2024a` | active     | Aug '24  | 2.42       | 13.3.0 | 5.0.3      | 3.4.4       | 0.3.27     | (incl. with FlexiBLAS) | 2.2.0       | 3.3.10      |
+| `2023b` | active     | Dec '23  | 2.40       | 13.2.0 | 4.1.6      | 3.3.1       | 0.3.24     | (incl. with FlexiBLAS) | 2.2.0       | 3.3.10      |
+| `2023a` | active     | Jun '23  | 2.40       | 12.3.0 | 4.1.5      | 3.3.1       | 0.3.23     | (incl. with FlexiBLAS) | 2.2.0       | 3.3.10      |
+| `2022b` | active     | Dec '22  | 2.39       | 12.2.0 | 4.1.4      | 3.2.1       | 0.3.21     | (incl. with FlexiBLAS) | 2.2.0       | 3.3.10      |
+| `2022a` | active     | Jun '22  | 2.38       | 11.3.0 | 4.1.4      | 3.2.0       | 0.3.20     | (incl. with FlexiBLAS) | 2.2.0       | 3.3.10      |
+| `2021b` | active     | Oct '21  | 2.37       | 11.2.0 | 4.1.1      | 3.0.4       | 0.3.18     | (incl. with FlexiBLAS) | 2.1.0       | 3.3.10      |
+| `2021a` | deprecated | May '21  | 2.36.1     | 10.3.0 | 4.1.1      | 3.0.4       | 0.3.15     | (incl. with FlexiBLAS) | 2.1.0       | 3.3.9       |
+| `2020b` | deprecated | Nov '20  | 2.35       | 10.2.0 | 4.0.5      | *(none)*    | 0.3.12     | (incl. with OpenBLAS)  | 2.1.0       | 3.3.8       |
+| `2020a` | archived   | May '20  | 2.34       | 9.3.0  | 4.0.3      | *(none)*    | 0.3.9      | (incl. with OpenBLAS)  | 2.1.0       | 3.3.8       |
+| `2019b` | archived   | Sept '19 | 2.32       | 8.3.0  | 3.1.4      | *(none)*    | 0.3.7      | (incl. with OpenBLAS)  | 2.0.2       | 3.3.8       |
+| `2019a` | archived   | Jan '19  | 2.31.1     | 8.2.0  | 3.1.3      | *(none)*    | 0.3.5      | (incl. with OpenBLAS)  | 2.0.2       | 3.3.8       |
+| `2018b` | archived   | Jul '18  | 2.30       | 7.3.0  | 3.1.1      | *(none)*    | 0.3.1      | (incl. with OpenBLAS)  | 2.0.2       | 3.3.8       |
+| `2018a` | archived   | Jan '18  | 2.28       | 6.4.0  | 2.1.2      | *(none)*    | 0.2.20\*   | (incl. with OpenBLAS)  | 2.0.2       | 3.3.7       |
+| `2017b` | archived   | Jul '17  | 2.28       | 6.4.0  | 2.1.1      | *(none)*    | 0.2.20\*   | (incl. with OpenBLAS)  | 2.0.2       | 3.3.6(-pl2) |
+| `2017a` | archived   | Jan '17  | 2.27       | 6.3.0  | 2.0.2      | *(none)*    | 0.2.19     | 3.7.0                  | 2.0.2       | 3.3.6(-pl2) |
+| `2016b` | archived   | Jul '16  | 2.26       | 5.4.0  | 1.10.3     | *(none)*    | 0.2.18     | 3.6.1                  | 2.0.2       | 3.3.4       |
+| `2016a` | archived   | Jan '16  | 2.25       | 4.9.3  | 1.10.2     | *(none)*    | 0.2.15     | 3.6.0                  | 2.0.2       | 3.3.4       |
+| `2015b` | archived   | Jul '15  | 2.25       | 4.9.3  | 1.8.8      | *(none)*    | 0.2.14     | 3.5.0                  | 2.0.2       | 3.3.4       |
+| `2015a` | archived   | Jan '15  | '*(none)*  | 4.9.2  | 1.8.4      | *(none)*    | 0.2.13     | 3.5.0                  | 2.0.2       | 3.3.4       |
+| `2014b` | archived   | Jul '14  | '*(none)*  | 4.8.3  | 1.8.1      | *(none)*    | 0.2.9      | 3.5.0                  | 2.0.2       | 3.3.4       |
 
 *(components marked with* \* *were patched)*
 
-### Component versions in `intel` toolchain (deprecated versions) {: #common_toolchains_overview_intel_deprecated }
+### Component versions in `intel` toolchain {: #common_toolchains_overview_intel }
 
-| `intel` | *date*   | *binutils* | *GCC*  | *Intel compilers* | *Intel MPI* | *Intel MKL* |
-|---------|----------|------------|--------|-------------------|-------------|-------------|
-| `2014b` | Jul '14  | '*(none)*  | 4.8.3  | 2013.5.192        | 4.1.3.049   | 11.1.2.144  |
-| `2015a` | Jan '15  | '*(none)*  | 4.9.2  | 2015.1.133        | 5.0.2.044   | 11.2.1.133  |
-| `2015b` | Jul '15  | 2.25       | 4.9.3  | 2015.3.187        | 5.0.3.048   | 11.2.3.187  |
-| `2016a` | Jan '16  | 2.26       | 4.9.3  | 2016.1.150        | 5.1.2.150   | 11.3.1.150  |
-| `2016b` | Jul '16  | 2.26       | 5.4.0  | 2016.3.210        | 5.1.3.181   | 11.3.3.210  |
-| `2017a` | Jan '17  | 2.27       | 6.3.0  | 2017.1.132        | 2017.1.132  | 2017.1.132  |
-| `2017b` | Jul '17  | 2.28       | 6.4.0  | 2017.4.196        | 2017.3.196  | 2017.3.196  |
-| `2018a` | Jan '18  | 2.28       | 6.4.0  | 2018.1.163        | 2018.1.163  | 2018.1.163  |
-| `2018b` | Jul '18  | 2.30       | 7.3.0  | 2018.3.222        | 2018.3.222  | 2018.3.222  |
-| `2019a` | Jan '19  | 2.31.1     | 8.2.0  | 2019.1.144        | 2018.4.274  | 2019.1.144  |
-| `2019b` | Sept '19 | 2.32       | 8.3.0  | 2019.5.281        | 2018.5.288  | 2019.5.281  |
-| `2020a` | May '20  | 2.34       | 9.3.0  | 2020.1.217        | 2019.7.217  | 2020.1.217  |
-| `2020b` | Nov '20  | 2.35       | 10.2.0 | 2020.4.304        | 2019.9.304  | 2020.4.304  |
+| `intel` | *support*  | *date*   | *binutils* | *GCC*  | *Intel compilers* | *Intel MPI* | *Intel MKL* |
+|---------|------------|----------|------------|--------|-------------------|-------------|-------------|
+| `2024a` | active     | Aug '24  | 2.42       | 13.3.0 | 2024.2.0          | 2021.13.0   | 2024.2.0    |
+| `2023b` | active     | Dec '23  | 2.40       | 13.2.0 | 2023.2.1          | 2021.10.1   | 2023.2.0    |
+| `2023a` | active     | Jun '23  | 2.40       | 12.3.0 | 2023.1.0          | 2021.9.1    | 2023.1.0    |
+| `2022b` | active     | Dec '22  | 2.39       | 12.2.0 | 2022.2.1          | 2021.7.1    | 2022.2.1    |
+| `2022a` | active     | Jun '22  | 2.38       | 11.3.0 | 2022.1.0          | 2021.6.0    | 2022.1.0    |
+| `2021b` | active     | Oct '21  | 2.37       | 11.2.0 | 2021.4.0          | 2021.4.0    | 2021.4.0    |
+| `2021a` | deprecated | May '21  | 2.36.1     | 10.3.0 | 2021.2.0          | 2021.2.0    | 2021.2.0    |
+| `2020b` | deprecated | Nov '20  | 2.35       | 10.2.0 | 2020.4.304        | 2019.9.304  | 2020.4.304  |
+| `2020a` | archived   | May '20  | 2.34       | 9.3.0  | 2020.1.217        | 2019.7.217  | 2020.1.217  |
+| `2019b` | archived   | Sept '19 | 2.32       | 8.3.0  | 2019.5.281        | 2018.5.288  | 2019.5.281  |
+| `2019a` | archived   | Jan '19  | 2.31.1     | 8.2.0  | 2019.1.144        | 2018.4.274  | 2019.1.144  |
+| `2018b` | archived   | Jul '18  | 2.30       | 7.3.0  | 2018.3.222        | 2018.3.222  | 2018.3.222  |
+| `2018a` | archived   | Jan '18  | 2.28       | 6.4.0  | 2018.1.163        | 2018.1.163  | 2018.1.163  |
+| `2017b` | archived   | Jul '17  | 2.28       | 6.4.0  | 2017.4.196        | 2017.3.196  | 2017.3.196  |
+| `2017a` | archived   | Jan '17  | 2.27       | 6.3.0  | 2017.1.132        | 2017.1.132  | 2017.1.132  |
+| `2016b` | archived   | Jul '16  | 2.26       | 5.4.0  | 2016.3.210        | 5.1.3.181   | 11.3.3.210  |
+| `2016a` | archived   | Jan '16  | 2.26       | 4.9.3  | 2016.1.150        | 5.1.2.150   | 11.3.1.150  |
+| `2015b` | archived   | Jul '15  | 2.25       | 4.9.3  | 2015.3.187        | 5.0.3.048   | 11.2.3.187  |
+| `2015a` | archived   | Jan '15  | '*(none)*  | 4.9.2  | 2015.1.133        | 5.0.2.044   | 11.2.1.133  |
+| `2014b` | archived   | Jul '14  | '*(none)*  | 4.8.3  | 2013.5.192        | 4.1.3.049   | 11.1.2.144  |
 
 ## Customizing common toolchains {: #common_toolchains_customizing }
 

--- a/docs/deprecated-easyconfigs.md
+++ b/docs/deprecated-easyconfigs.md
@@ -43,99 +43,41 @@ changes to the EasyBuild framework or relevant easyblocks).
 In a future major version of EasyBuild, these easyconfig files will be
 archived (see also [Archived easyconfigs][archived_easyconfigs]).
 
-## Deprecated toolchains {: #deprecated_easyconfigs_toolchains }
+## Deprecated and archived toolchains {: #deprecated_easyconfigs_toolchains }
 
-Overview of deprecated toolchains:
+Our [support policy on toolchain generations][policy_toolchains] determines the
+lifespan of toolchains in EasyBuild repositories. Once a toolchain becomes
+deprecated, it will stop being actively developed and tested. Once it becomes
+archived, it is transferred into the
+[easybuild-easyconfigs-archive](https://github.com/easybuilders/easybuild-easyconfigs-archive)
+repository.
 
-- [`foss` and `fosscuda` toolchain][deprecated_easyconfigs_toolchains_foss]
-- [`GCCcore` and `GCC` toolchains][deprecated_easyconfigs_toolchains_gcc]
-- [`gcccuda` toolchain][deprecated_easyconfigs_toolchains_gcccuda]
-- [`gompi` and `gompic` toolchains][deprecated_easyconfigs_toolchains_gompi]
-- [`goolf` and `goolfc` toolchains][deprecated_easyconfigs_toolchains_goolf]
-- [`ictce` toolchain][deprecated_easyconfigs_toolchains_ictce]
-- [`iccifort`, `iimpi`, `iimpic`, `intel`, and `intelcuda` toolchains][deprecated_easyconfigs_toolchains_intel]
-- [`iompi`, `iompic`, `iomkl`, and `iomklc` toolchains][deprecated_easyconfigs_toolchains_iomkl]
+## Obsolete toolchains {: #obsolete_easyconfigs_toolchains }
 
-### `foss` and `fosscuda` toolchain {: #deprecated_easyconfigs_toolchains_foss }
+Some toolchains might become obsolete, this means that they will not receive
+any new versions and ultimately be completely archived. Overview of obselete
+toolchains:
 
-- *deprecated since:* EasyBuild v4.5.0
-- *will be archived in:* EasyBuild v5.0.0
+### Toolchains with CUDA {: #obsolete_easyconfigs_toolchains_cuda }
 
-The oldest versions of the `foss` and `fosscuda` toolchains have been
-deprecated, which currently includes any version older than `foss/2019a`
-and `fosscuda/2019a`.
+- *deprecated since:* EasyBuild v4.9.0
+- *will be archived in:* EasyBuild v5.1.0
 
-### `GCCcore` and `GCC` toolchains {: #deprecated_easyconfigs_toolchains_gcc }
+The following toolchains are obsolete: `gcccuda`, `gompic`, `goolfc`,
+`intelcuda`, `iomklc`.
 
-- *deprecated since:* EasyBuild v4.5.0
-- *will be archived in:* EasyBuild v5.0.0
+Since the `2021a` toolchain generation, CUDA is included as a regular
+dependency in common toolchains instead of having specific toolchains including
+CUDA in their definition. This approach is more flexible and avoids duplication
+of identical easyconfigs between CUDA and non-CUDA toolchains.
 
-The oldest versions of the `GCCcore` and `GCC` toolchains have been
-deprecated, which currently includes any version older than `8.0`.
+### Toolchains with legacy Intel compilers {: #obsolete_easyconfigs_toolchains_iccifort }
 
-### `gcccuda` toolchain {: #deprecated_easyconfigs_toolchains_gcccuda }
+- *deprecated since:* EasyBuild v4.9.0
+- *will be archived in:* EasyBuild v5.1.0
 
-- *deprecated since:* EasyBuild v4.5.0
-- *will be archived in:* EasyBuild v5.0.0
+The following toolchains are obsolete: `icc`, `ifort`, `iccifort`.
 
-The oldest versions of the `gcccuda` toolchains have been deprecated,
-which currently includes any version older than `gcccuda/2019a`.
-
-### `gompi` and `gompic` toolchains {: #deprecated_easyconfigs_toolchains_gompi }
-
-- *deprecated since:* EasyBuild v4.5.0
-- *will be archived in:* EasyBuild v5.0.0
-
-Versions of the `gompi` and `gompic` toolchains that were used as a
-subtoolchain for a deprecated toolchain have also been deprecated; this
-includes versions older than `gompi/2019a` and `gompic/2019a`.
-
-### `goolf` and `goolfc` toolchains {: #deprecated_easyconfigs_toolchains_goolf }
-
-- *deprecated since:* EasyBuild v3.8.0
-- *archived in:* EasyBuild v4.0.0
-
-The `goolf` and `goolfc` toolchains have been deprecated, since they are
-superseded by the [`foss` toolchain][common_toolchains_foss]
-and `fosscuda` toolchains, respectively.
-
-The `foss*` toolchains are equivalent to the `goolf*` toolchains, except
-that `binutils` is also included as a companion to `GCC(core)` in the
-`foss*` toolchains.
-
-### `ictce` toolchain {: #deprecated_easyconfigs_toolchains_ictce }
-
-- *deprecated since:* EasyBuild v3.8.0
-- *archived in:* EasyBuild v4.0.0
-
-The `ictce` toolchain has been deprecated, since it is superseded by the
-[`intel` toolchain][common_toolchains_intel].
-
-The `ictce` toolchain is equivalent to `intel` w.r.t. toolchain
-components, except that `binutils` is also included as a companion to
-`GCC(core)` (which serves as a base for the Intel compilers) in the
-`intel` toolchain.
-
-### `iccifort`, `iimpi`, `iimpic`, `intel`, and `intelcuda` toolchains {: #deprecated_easyconfigs_toolchains_intel }
-
-- *deprecated since:* EasyBuild v4.5.0
-- *will be archived in:* EasyBuild v5.0.0
-
-The oldest versions of the `iccifort`, `iimpi` and
-[`intel` toolchain][common_toolchains_intel] have been
-deprecated.
-
-Deprecated versions include:
-
-- `iccifort` versions older than `2019.0`
-- `iimpi` and `iimpic` versions older than `2019a`
-- `intel` and `intelcuda` versions older than `2019a`
-
-### `iompi`, `iompic`, `iomkl`, and `iomklc` toolchains {: #deprecated_easyconfigs_toolchains_iomkl }
-
-- *deprecated since:* EasyBuild v4.5.0
-- *will be archived in:* EasyBuild v5.0.0
-
-The oldest versions of the `iompi`, `iompic`, `iomkl` and `iomklc`
-toolchains have been deprecated, which currently includes any version
-older than `2019a`.
+Since the `2021a` toolchain generation, toolchains based on legacy Intel
+compilers have been replaced by the new `intel-compilers` toolchain based on
+the oneAPI compilers from Intel.

--- a/docs/easybuild-v5/enhancements.md
+++ b/docs/easybuild-v5/enhancements.md
@@ -10,6 +10,7 @@ Various significant enhancements are included in EasyBuild v5.0, including:
 - [Mark support for installing extensions in parallel as stable (no longer experimental)][parallel-extensions-install-stable]
 - [Mark easystack support as stable (no longer experimental)][easystack-stable]
 - [Reproducible tarballs for sources created via `git_config`][reproducible-tarballs-git_config]
+- [New house for the archive of easyconfigs][new-easyconfig-archive]
 - [Granular exit codes][granular-exit-codes]
 - [Copy build directory and/or log file(s) if installation failed to path specified via `--failed-install-build-dirs-path` or `--failed-install-logs-path`][copy-build-log-failed-installs]
 - [Specify changes that should be made by generated module files via `module_load_environment`][module-load-environment]
@@ -57,21 +58,6 @@ generation, including the versions of toolchains and dependencies for instance.
 
 If you would like to see other types of easyconfigs added as templates, please
 [open an issue or pull request with your suggestion][contributing].
-
----
-
-## Granular exit codes { : #granular-exit-codes }
-
-EasyBuild v5 now uses a range of ~50 exit codes instead of just 0 for normal
-termination and 1 for unexpected termination. Each non-zero exit code
-correlates to the specific type of error or failure that caused the
-termination of the program. For instance, a missing easyconfig or a failed
-checksum check. The full list of exit codes is defined in the class
-[easybuild.tools.build_log.EasyBuildExit](https://github.com/easybuilders/easybuild-framework/blob/main/easybuild/tools/build_log.py#L74).
-
-EasyBuild will always return its own exit codes on termination. Other exit
-codes from external processes executed through `run_shell_cmd` or HTTP response
-status codes are reported in the corresponding logs.
 
 ---
 
@@ -129,6 +115,53 @@ tarballs. Archives will be created in `.tar.xz` format and checksums will be
 validated on Python 3.9+. Therefore, beware that EasyBuild 5.0 might generate
 new archives for sources that were already cloned in your system due to this
 changes in format.
+
+---
+
+## New house for the archive of easyconfigs { : #new-easyconfig-archive }
+
+The collection of old unsupported easyconfig files located inside the `__archive__` folder in our
+[easybuilders/easybuild-easyconfigs](https://github.com/easybuilders/easybuild-easyconfigs)
+repository has been moved into its own repository at
+[easybuilders/easybuild-easyconfigs-archive](https://github.com/easybuilders/easybuild-easyconfigs-archive).
+
+This operation has reduced the number of files in the `easybuild-easyconfigs`
+repository by 12765 files (11378 easyconfigs and 1387 patch files). Such a
+drastic reduction in the number of files has two main advantages:
+
+- the tarball of easyconfigs (`easybuild_easyconfigs-5.0.0.tar.gz`) is 4.5 MB
+smaller than in v4.9.4, 58% of the size
+
+- the execution of Git commands on the `easybuild_easyconfigs` repository is much
+faster
+
+The archive of old easyconfigs is now an opt-in installation that can be easily
+enabled in `pip` with the `archive` _extra_ of the `easybuild-easyconfigs`
+package:
+
+```shell
+python -m pip install easybuild-easyconfigs[archive]
+```
+This will result in the same installation layout as in v4.9. All _active_
+easyconfigs will be placed in alphabetical folders and the archive of
+easyconfigs will be placed inside the `__archive__` folder.
+
+See [Archived easyconfigs][archived_easyconfigs] for more information.
+
+---
+
+## Granular exit codes { : #granular-exit-codes }
+
+EasyBuild v5 now uses a range of ~50 exit codes instead of just 0 for normal
+termination and 1 for unexpected termination. Each non-zero exit code
+correlates to the specific type of error or failure that caused the
+termination of the program. For instance, a missing easyconfig or a failed
+checksum check. The full list of exit codes is defined in the class
+[easybuild.tools.build_log.EasyBuildExit](https://github.com/easybuilders/easybuild-framework/blob/main/easybuild/tools/build_log.py#L74).
+
+EasyBuild will always return its own exit codes on termination. Other exit
+codes from external processes executed through `run_shell_cmd` or HTTP response
+status codes are reported in the corresponding logs.
 
 ---
 

--- a/docs/easybuild-v5/index.md
+++ b/docs/easybuild-v5/index.md
@@ -71,6 +71,7 @@ Various significant enhancements are included in EasyBuild v5.0, including:
 - [Mark support for installing extensions in parallel as stable (no longer experimental)](enhancements.md#parallel-extensions-install-stable)
 - [Mark easystack support as stable (no longer experimental)](enhancements.md#easystack-stable)
 - [Reproducible tarballs for sources created via `git_config`](enhancements.md#reproducible-tarballs-git_config)
+- [New house for the archive of easyconfigs](enhancements.md#new-easyconfig-archive)
 - [Granular exit codes](enhancements.md#granular-exit-codes)
 - [Copy build directory and/or log file(s) if installation failed to path specified via `--failed-install-build-dirs-path` or `--failed-install-logs-path`](enhancements.md#copy-build-log-failed-installs)
 - [Specify changes that should be made by generated module files via `module_load_environment`](../implementing-easyblocks.md#module_load_environment)

--- a/docs/policies/toolchains.md
+++ b/docs/policies/toolchains.md
@@ -1,6 +1,6 @@
 # Supported Toolchain Generations Policy {: #policy_toolchains }
 
-For the central EasyBuild repositories, we support a set of toolchain generations.
+For the central EasyBuild repositories, we support a set of [common toolchain][common_toolchains] generations.
 
 * Accept PRs only for the 6 most recent toolchain generations.
 * Deprecate toolchains generations 7 and 8, including closing PRs and issues for these toolchains.


### PR DESCRIPTION
This PR updates the information in the documents: Archived easyconfigs, Deprecated easyconfigs and Common toolchains, with up-to-date information about deprecation and archival of toolchains:

* add mentions and links to the policy on supported toolchains
* explain differences between deprecation/archival
* update instructions on how to use the archive of easyconfigs
* replace list of deprecated toolchains with list of obsolete toolchains with a bit of explanation of why those were removed
