### PR TITLE
mention FlexiBLAS as toolchain component for foss toolchain rather than OpenBLAS

### DIFF
--- a/docs/version-specific/toolchains.md
+++ b/docs/version-specific/toolchains.md
@@ -15,7 +15,7 @@ Name               |Compiler(s)     |MPI          |Linear algebra           |FFT
 **CrayPGI**        |PrgEnv-pgi      |cray-mpich   |cray-libsci              |*(none)*
 **FCC**            |lang            |*(none)*     |*(none)*                 |*(none)*
 **ffmpi**          |FCC             |*(none)*     |*(none)*                 |*(none)*
-**foss**           |GCC             |OpenMPI      |OpenBLAS, ScaLAPACK      |FFTW
+**foss**           |GCC             |OpenMPI      |FlexiBLAS, ScaLAPACK     |FFTW
 **fosscuda**       |GCC, CUDA       |OpenMPI      |OpenBLAS, ScaLAPACK      |FFTW
 **Fujitsu**        |FCC             |*(none)*     |*(none)*                 |FFTW
 **GCC**            |GCC             |*(none)*     |*(none)*                 |*(none)*


### PR DESCRIPTION
Change from OpenBLAS to FlexiBLAS in the foss toolchain. This is to reflect the use of FlexiBLAS by this toolchain (https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/f/foss/foss-2025a.eb)