### PR TITLE
stick to MkDocs < 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs
+mkdocs<2.0
 mkdocs-material
 mkdocs-redirects
 mkdocs-git-revision-date-localized-plugin


### PR DESCRIPTION
"MkDocs 2.0 is incompatible with Material for MkDocs"
see https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/