### PR TITLE
fix: typo in "EasuBuild" [sic] AI policy

### DIFF
--- a/docs/policies/ai.md
+++ b/docs/policies/ai.md
@@ -75,4 +75,4 @@ Examples of statements to declare the use of AI are:
 
 ### v1.0 (19 April 2026)
 
-Initial EasuBuild AI policy
+Initial EasyBuild AI policy


### PR DESCRIPTION
I don't normally go around fixing typos in policies, but it's in the project name in this case :-)

No AI used. I noticed the typo fully on my own.